### PR TITLE
lets allow the exposer to be configured via env var on k8s

### DIFF
--- a/openshift/kube_token.go
+++ b/openshift/kube_token.go
@@ -154,6 +154,10 @@ func LoadExposeControllerVariables(config Config) (map[string]string, error) {
 			answer["EXPOSER"] = configData["exposer"]
 		}
 	}
+	exposer := os.Getenv("TENANT_EXPOSER")
+	if len(exposer) > 0 {
+		answer["EXPOSER"] = exposer
+	}
 	return answer, nil
 }
 


### PR DESCRIPTION
support vanilla kubernetes for init tenant