### PR TITLE
Split init and update strategy

### DIFF
--- a/controller/tenant.go
+++ b/controller/tenant.go
@@ -132,7 +132,7 @@ func (c *TenantController) Update(ctx *app.UpdateTenantContext) error {
 		if openshift.KubernetesMode() {
 			oc = userConfig
 		}
-		err = openshift.InitTenant(
+		err = openshift.UpdateTenant(
 			ctx,
 			c.keycloakConfig,
 			oc,


### PR DESCRIPTION
Rely on Async REST method to init Che and Jenkins,
while using oc apply on Che and Jenkins update.

REST method is a lot faster, and since there is nothing
to update at this point we can do a simple brute force POST/DELETE/POST
session.

* Removed Reorder of templates since they now come ordered from upstream.

Fixes #167