### PR TITLE
lazily setup or update the tenant for kubernetes

### DIFF
--- a/main.go
+++ b/main.go
@@ -134,7 +134,7 @@ func main() {
 	app.MountTenantController(service, tenantCtrl)
 
 	// Mount "tenantkube" controller
-	tenanKubetCtrl := controller.NewTenantKubeController(service, tenant.NewDBService(db), keycloakConfig, openshiftConfig)
+	tenanKubetCtrl := controller.NewTenantKubeController(service, tenant.NewDBService(db), keycloakConfig, openshiftConfig, templateVars)
 	app.MountTenantKubeController(service, tenanKubetCtrl)
 
 	// Mount "auth" controller

--- a/openshift/kube_keycloak.go
+++ b/openshift/kube_keycloak.go
@@ -15,7 +15,6 @@ import (
 	"github.com/fabric8-services/fabric8-tenant/keycloak"
 )
 
-//  kcConfig keycloak.Config only used to match signature
 func KubeConnected(kcConfig keycloak.Config, config Config, username string) (string, error) {
 	if KubernetesMode() {
 		name := createName(username)
@@ -23,6 +22,20 @@ func KubeConnected(kcConfig keycloak.Config, config Config, username string) (st
 		return EnsureKeyCloakHasJenkinsRedirectURL(config, kcConfig, jenkinsNS)
 	}
 	return "not required for OpenShift", nil
+}
+
+// HasJenkinsNamespace returns true if the tenant namespace has been created
+func HasJenkinsNamespace(config Config, username string) bool {
+	if KubernetesMode() {
+		name := createName(username)
+		jenkinsNS := fmt.Sprintf("%v-jenkins", name)
+		namespaceURL := fmt.Sprintf("/api/v1/namespaces/%s", jenkinsNS)
+		ns, err := getResource(config, namespaceURL)
+		if ns != nil && err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // EnsureKeyCloakHasJenkinsRedirectURL checks that the client has a redirect URI for the jenkins URL


### PR DESCRIPTION
if for some reason the tenant did not get setup before we go to _gettingstarted lets ensure that the tenant gets setup or updated so that the jenkins namespace is setup before checking the jenkins redirectURI is populated correctly