### PR TITLE
Lock down access to the users namespaces

### DIFF
--- a/controller/tenant.go
+++ b/controller/tenant.go
@@ -77,7 +77,6 @@ func (c *TenantController) Setup(ctx *app.SetupTenantContext) error {
 		oc := c.openshiftConfig
 		err = openshift.RawInitTenant(
 			ctx,
-			c.keycloakConfig,
 			oc,
 			InitTenant(ctx, c.openshiftConfig.MasterURL, c.tenantService, t),
 			openshiftUser,
@@ -132,13 +131,12 @@ func (c *TenantController) Update(ctx *app.UpdateTenantContext) error {
 		if openshift.KubernetesMode() {
 			oc = userConfig
 		}
-		err = openshift.UpdateTenant(
+		err = openshift.RawUpdateTenant(
 			ctx,
 			c.keycloakConfig,
 			oc,
 			InitTenant(ctx, c.openshiftConfig.MasterURL, c.tenantService, t),
 			openshiftUser,
-			openshiftUserToken,
 			c.templateVars)
 
 		if err != nil {

--- a/controller/tenant_kube.go
+++ b/controller/tenant_kube.go
@@ -81,7 +81,6 @@ func (c *TenantKubeController) KubeConnected(ctx *app.KubeConnectedTenantKubeCon
 				} else {
 					err = openshift.RawInitTenant(
 						ctx,
-						c.keycloakConfig,
 						c.openshiftConfig,
 						InitTenant(ctx, c.openshiftConfig.MasterURL, c.tenantService, tenant),
 						openshiftUser,

--- a/openshift/process_template.go
+++ b/openshift/process_template.go
@@ -38,6 +38,20 @@ func IsNotOfKind(kinds ...string) FilterFunc {
 	}
 }
 
+func RemoveReplicas(vs []map[interface{}]interface{}) []map[interface{}]interface{} {
+	vsf := make([]map[interface{}]interface{}, 0)
+	for _, v := range vs {
+		if GetKind(v) == ValKindDeploymentConfig {
+			if spec, specFound := v[FieldSpec].(map[interface{}]interface{}); specFound {
+				delete(spec, FieldReplicas)
+			}
+		}
+		vsf = append(vsf, v)
+	}
+	return vsf
+
+}
+
 func ProcessTemplate(template, namespace string, vars map[string]string) ([]map[interface{}]interface{}, error) {
 	pt, err := Process(template, vars)
 	if err != nil {


### PR DESCRIPTION
* DELETE admin role in namespce 'user' on init

All other changes are reflected in the templates.

Update now assumes namespaces will be there and will not
recreate them. Each namespace is updated via oc apply in parallel.