### PR TITLE
Add +1 addition parameter to teams template test

### DIFF
--- a/template/generate_test.go
+++ b/template/generate_test.go
@@ -115,5 +115,6 @@ func TestFoundTeam(t *testing.T) {
 	if !ok {
 		t.Fatalf("parameters not found")
 	}
-	assert.Equal(t, 5, len(params), "unknown number of parameters")
+	// 1 parameter not used in Openshift templates but bleed through from k8
+	assert.Equal(t, 6, len(params), "unknown number of parameters")
 }


### PR DESCRIPTION
Fabric8-Maven-Plugin does not separate between the parameters
required in the Openshift and the K8 templates. Even tho
the new parameter is not used in the Openshfit templates it's
defined in the template spec.