### PR TITLE
ensure remote resource management is enabled on keycloak for k8s

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM fabric8/fabric8-tenant:v0bcd033
+FROM fabric8/fabric8-tenant:ve664885
 
 COPY fabric8-tenant-linux /usr/local/fabric8-tenant/bin/fabric8-tenant
 RUN echo chmod +x /usr/local/fabric8-tenant/bin/fabric8-tenant


### PR DESCRIPTION
fixes https://github.com/fabric8-services/fabric8-auth/issues/91
by ensuring these settings are preserved during the update of the jenkins redirect URI