### PR TITLE
Quick fix for Che SSO URL

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -334,7 +334,7 @@ func (c *Data) GetTemplateValues() (map[string]string, error) {
 		"RECOMMENDER_EXTERNAL_NAME": c.v.GetString(varTemplateRecommenderExternalName),
 		"RECOMMENDER_API_TOKEN":     base64.StdEncoding.EncodeToString([]byte(c.v.GetString(varTemplateRecommenderAPIToken))),
 		"DOMAIN":                    c.v.GetString(varTemplateDomain),
-		"CHE_KEYCLOAK_AUTH__SERVER__URL": c.GetKeycloakURL(),
+		"CHE_KEYCLOAK_AUTH__SERVER__URL": c.GetKeycloakURL() + "/auth",
 		"CHE_KEYCLOAK_REALM":             c.GetKeycloakRealm(),
 		"CHE_KEYCLOAK_CLIENT__ID":        c.GetKeycloakClientID(),
 	}, nil


### PR DESCRIPTION
CheHost require half a URL configured, not just base.

https://github.com/fabric8-services/fabric8-tenant-che/pull/60#pullrequestreview-75477878

Related to fabric8-services/fabric8-tenant-che#60