### PR TITLE
Add support for Multi Tenant Che tenant install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,12 +86,14 @@ auth
 bin/
 
 #Ignore dynamically downloaded templates
+template/fabric8-tenant-che-mt-openshift.yml
 template/fabric8-tenant-che-openshift.yml
 template/fabric8-tenant-che-quotas-oso-openshift.yml
 template/fabric8-tenant-jenkins-openshift.yml
 template/fabric8-tenant-jenkins-quotas-oso-openshift.yml
 template/fabric8-tenant-team-openshift.yml
 template/fabric8-tenant-che-kubernetes.yml
+template/fabric8-tenant-che-mt-kubernetes.yml
 template/fabric8-tenant-jenkins-kubernetes.yml
 template/fabric8-tenant-team-kubernetes.yml
 template/fabric8-tenant-expose-kubernetes.yml

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -34,6 +34,7 @@ const (
 	varKeycloakOpenshiftBroker         = "keycloak.openshift.broker"
 	varKeycloakURL                     = "keycloak.url"
 	varAuthURL                         = "auth.url"
+	varTogglesURL                      = "toggles.url"
 	varConsoleURL                      = "console.url"
 	varOpenshiftTenantMasterURL        = "openshift.tenant.masterurl"
 	varOpenshiftCheVersion             = "openshift.che.version"
@@ -121,6 +122,7 @@ func (c *Data) setConfigDefaults() {
 	c.v.SetDefault(varAPIServerInsecureSkipTLSVerify, false)
 	c.v.SetDefault(varAuthURL, defaultAuthURL)
 	c.v.SetDefault(varKeycloakClientID, defaultKeycloakClientID)
+	c.v.SetDefault(varTogglesURL, defaultTogglesURL)
 
 	// Enable development related features, e.g. token generation endpoint
 	c.v.SetDefault(varDeveloperModeEnabled, false)
@@ -262,6 +264,11 @@ func (c *Data) GetAuthURL() string {
 	return c.v.GetString(varAuthURL)
 }
 
+// GetTogglesURL returns Toggle service URL
+func (c *Data) GetTogglesURL() string {
+	return c.v.GetString(varTogglesURL)
+}
+
 // GetOpenshiftTenantMasterURL returns the URL for the openshift cluster where the tenant services are running
 func (c *Data) GetOpenshiftTenantMasterURL() string {
 	return c.v.GetString(varOpenshiftTenantMasterURL)
@@ -357,5 +364,6 @@ const (
 
 	defaultLogLevel = "info"
 
-	defaultWitURL = "https://api.prod-preview.openshift.io/api/"
+	defaultWitURL     = "https://api.prod-preview.openshift.io/api/"
+	defaultTogglesURL = "http://f8toggles"
 )

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 842ca86e131882249c01711429a4771047b7bbabc76ad4b0d58c98c100860553
-updated: 2017-11-01T21:13:24.270339554+01:00
+hash: 11d7ed58d948b60118aa58f7e7d2d71d8f2d231f507c2d3d3d318bf6dcbab9c7
+updated: 2017-11-12T00:05:38.194370944+01:00
 imports:
 - name: github.com/ajg/form
   version: cc2954064ec9ea8d93917f0f87456e11d7b881ad
@@ -131,6 +131,8 @@ imports:
   subpackages:
   - assert
   - require
+- name: github.com/Unleash/unleash-client-go
+  version: 5e8fdebb43e3dd7a8d25c4614925122b06c2ede3
 - name: github.com/zach-klippenstein/goregen
   version: 795b5e3961ea1912fde60af417ad85e86acc0d6a
 - name: golang.org/x/crypto

--- a/glide.yaml
+++ b/glide.yaml
@@ -39,6 +39,7 @@ import:
   version: c1b9cf186e4bcd8e5d566ef43f2ae2dfe22dc34e
 - package: github.com/spf13/cobra
 - package: github.com/spf13/viper
+- package: github.com/Unleash/unleash-client-go
 - package: github.com/golang/lint
   subpackages:
   - golint

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/fabric8-services/fabric8-tenant/migration"
 	"github.com/fabric8-services/fabric8-tenant/openshift"
 	"github.com/fabric8-services/fabric8-tenant/tenant"
+	"github.com/fabric8-services/fabric8-tenant/toggles"
 	witmiddleware "github.com/fabric8-services/fabric8-wit/goamiddleware"
 	"github.com/fabric8-services/fabric8-wit/log"
 	"github.com/goadesign/goa"
@@ -97,6 +98,8 @@ func main() {
 	if config.GetOpenshiftTemplateDir() != "" {
 		log.Logger().Infof("Template Dir: %s", config.GetOpenshiftTemplateDir())
 	}
+
+	toggles.Init("f8tenant", config.GetTogglesURL())
 
 	openshiftConfig := openshift.Config{
 		MasterURL:      config.GetOpenshiftTenantMasterURL(),

--- a/openshift/init_tenant.go
+++ b/openshift/init_tenant.go
@@ -447,6 +447,11 @@ func loadTemplate(config Config, name string) ([]byte, error) {
 	url := ""
 	if len(config.CheVersion) > 0 {
 		switch name {
+		// che-mt
+		case "fabric8-tenant-che-mt-kubernetes.yml":
+			url = "$MVN_REPO/io/fabric8/tenant/packages/fabric8-tenant-che-mt/$CHE_VERSION/fabric8-tenant-che-mt-$CHE_VERSION-k8s-template.yml"
+		case "fabric8-tenant-che-mt-openshift.yml":
+			url = "$MVN_REPO/io/fabric8/tenant/packages/fabric8-tenant-che-mt/$CHE_VERSION/fabric8-tenant-che-mt-$CHE_VERSION-openshift.yml"
 		// che
 		case "fabric8-tenant-che-kubernetes.yml":
 			url = "$MVN_REPO/io/fabric8/tenant/packages/fabric8-tenant-che/$CHE_VERSION/fabric8-tenant-che-$CHE_VERSION-k8s-template.yml"

--- a/openshift/process_template.go
+++ b/openshift/process_template.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/fabric8-services/fabric8-tenant/toggles"
 )
 
 type FilterFunc func(map[interface{}]interface{}) bool
@@ -126,7 +128,12 @@ func LoadProcessedTemplates(ctx context.Context, config Config, username string,
 		return nil, err
 	}
 
-	cheT, err := loadTemplate(config, "fabric8-tenant-che-"+extension)
+	cheType := ""
+	if toggles.IsEnabled(ctx, "deploy.che-multi-tenant", false) {
+		cheType = "mt-"
+	}
+
+	cheT, err := loadTemplate(config, "fabric8-tenant-che-"+cheType+extension)
 	if err != nil {
 		return nil, err
 	}

--- a/template/generate.go
+++ b/template/generate.go
@@ -1,3 +1,6 @@
+//go:generate sh -c "curl http://central.maven.org/maven2/io/fabric8/tenant/packages/fabric8-tenant-che-mt/$CHE_VERSION/fabric8-tenant-che-mt-$CHE_VERSION-k8s-template.yml > fabric8-tenant-che-mt-kubernetes.yml"
+//go:generate sh -c "curl http://central.maven.org/maven2/io/fabric8/tenant/packages/fabric8-tenant-che-mt/$CHE_VERSION/fabric8-tenant-che-mt-$CHE_VERSION-openshift.yml > fabric8-tenant-che-mt-openshift.yml"
+
 //go:generate sh -c "curl http://central.maven.org/maven2/io/fabric8/tenant/packages/fabric8-tenant-che/$CHE_VERSION/fabric8-tenant-che-$CHE_VERSION-k8s-template.yml > fabric8-tenant-che-kubernetes.yml"
 //go:generate sh -c "curl http://central.maven.org/maven2/io/fabric8/tenant/packages/fabric8-tenant-che/$CHE_VERSION/fabric8-tenant-che-$CHE_VERSION-openshift.yml > fabric8-tenant-che-openshift.yml"
 //go:generate sh -c "curl http://central.maven.org/maven2/io/fabric8/tenant/packages/fabric8-tenant-che-quotas-oso/$CHE_VERSION/fabric8-tenant-che-quotas-oso-$CHE_VERSION-openshift.yml > fabric8-tenant-che-quotas-oso-openshift.yml"

--- a/template/generate_test.go
+++ b/template/generate_test.go
@@ -80,6 +80,31 @@ func TestFoundChe(t *testing.T) {
 	assert.Equal(t, 10, len(params), "unknown number of parameters")
 }
 
+func TestFoundCheMultiTenant(t *testing.T) {
+	c, err := template.Asset("template/fabric8-tenant-che-mt-openshift.yml")
+	if err != nil {
+		t.Fatalf("Asset template/fabric8-tenant-che-mt-openshift.yml not found")
+	}
+
+	cs := string(c)
+	if !strings.Contains(cs, "claim-che-workspace") {
+		t.Fatalf("Word claim-che-workspace not found in the template")
+	}
+
+	var template map[interface{}]interface{}
+	err = yaml.Unmarshal(c, &template)
+	if err != nil {
+		t.Fatalf("Could not parse template as yaml")
+	}
+
+	params, ok := template["parameters"].([]interface{})
+	if !ok {
+		t.Fatalf("parameters not found")
+	}
+
+	assert.Equal(t, 1, len(params), "unknown number of parameters")
+}
+
 func TestFoundCheQuotasOSO(t *testing.T) {
 	c, err := template.Asset("template/fabric8-tenant-che-quotas-oso-openshift.yml")
 	if err != nil {

--- a/toggles/toggles.go
+++ b/toggles/toggles.go
@@ -12,6 +12,8 @@ import (
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 )
 
+var ready = false
+
 // Init toggle client lib
 func Init(serviceName, hostURL string) {
 	unleash.Initialize(
@@ -39,6 +41,9 @@ func WithContext(ctx context.Context) unleash.FeatureOption {
 
 // IsEnabled wraps unleash for a simpler API
 func IsEnabled(ctx context.Context, feature string, fallback bool) bool {
+	if !ready {
+		return fallback
+	}
 	return unleash.IsEnabled(feature, WithContext(ctx), unleash.WithFallback(fallback))
 }
 
@@ -60,6 +65,7 @@ func (l listener) OnWarning(warning error) {
 
 // OnReady prints to the console when the repository is ready.
 func (l listener) OnReady() {
+	ready = true
 	log.Info(nil, map[string]interface{}{}, "toggles ready")
 }
 

--- a/toggles/toggles.go
+++ b/toggles/toggles.go
@@ -1,0 +1,86 @@
+package toggles
+
+import (
+	"context"
+	"os"
+	"time"
+
+	unleash "github.com/Unleash/unleash-client-go"
+	ucontext "github.com/Unleash/unleash-client-go/context"
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/fabric8-services/fabric8-wit/log"
+	goajwt "github.com/goadesign/goa/middleware/security/jwt"
+)
+
+// Init toggle client lib
+func Init(serviceName, hostURL string) {
+	unleash.Initialize(
+		unleash.WithAppName(serviceName),
+		unleash.WithInstanceId(os.Getenv("HOSTNAME")),
+		unleash.WithUrl(hostURL),
+		unleash.WithMetricsInterval(5*time.Minute),
+		unleash.WithRefreshInterval(1*time.Minute),
+		unleash.WithListener(&listener{}),
+	)
+}
+
+// WithContext creates a Token based contex
+func WithContext(ctx context.Context) unleash.FeatureOption {
+	uctx := ucontext.Context{}
+	token := goajwt.ContextJWT(ctx)
+	if token != nil {
+		if claims, ok := token.Claims.(jwt.MapClaims); ok {
+			uctx.UserId = claims["sub"].(string)
+			uctx.SessionId = claims["session_state"].(string)
+		}
+	}
+	return unleash.WithContext(uctx)
+}
+
+// IsEnabled wraps unleash for a simpler API
+func IsEnabled(ctx context.Context, feature string, fallback bool) bool {
+	return unleash.IsEnabled(feature, WithContext(ctx), unleash.WithFallback(fallback))
+}
+
+type listener struct{}
+
+// OnError prints out errors.
+func (l listener) OnError(err error) {
+	log.Error(nil, map[string]interface{}{
+		"err": err.Error(),
+	}, "toggles error")
+}
+
+// OnWarning prints out warning.
+func (l listener) OnWarning(warning error) {
+	log.Warn(nil, map[string]interface{}{
+		"err": warning.Error(),
+	}, "toggles warning")
+}
+
+// OnReady prints to the console when the repository is ready.
+func (l listener) OnReady() {
+	log.Info(nil, map[string]interface{}{}, "toggles ready")
+}
+
+// OnCount prints to the console when the feature is queried.
+func (l listener) OnCount(name string, enabled bool) {
+	log.Info(nil, map[string]interface{}{
+		"name":    name,
+		"enabled": enabled,
+	}, "toggles count")
+}
+
+// OnSent prints to the console when the server has uploaded metrics.
+func (l listener) OnSent(payload unleash.MetricsData) {
+	log.Info(nil, map[string]interface{}{
+		"payload": payload,
+	}, "toggles sent")
+}
+
+// OnRegistered prints to the console when the client has registered.
+func (l listener) OnRegistered(payload unleash.ClientData) {
+	log.Info(nil, map[string]interface{}{
+		"payload": payload,
+	}, "toggles registered")
+}


### PR DESCRIPTION
Toggle deploy.che-multi-tenant is used during rollout period.

Related to redhat-developer/rh-che#404