### PR TITLE
Add `requestId` and `identityId` to the template variables for the Che migration job POD

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -347,6 +347,8 @@ func (c *Data) GetTemplateValues() (map[string]string, error) {
 		"CHE_KEYCLOAK_CLIENT__ID":        c.GetKeycloakClientID(),
 		"CHE_MULTITENANT_SERVER":         c.v.GetString(varTemplateCheMultiTenantServer),
 		"OSIO_TOKEN":                     "", // set per request
+		"IDENTITY_ID":                    "", // set per request
+		"REQUEST_ID":                     "", // set per request
 	}, nil
 }
 

--- a/openshift/process_template.go
+++ b/openshift/process_template.go
@@ -11,7 +11,7 @@ import (
 	"github.com/fabric8-services/fabric8-tenant/toggles"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 	jwt "github.com/dgrijalva/jwt-go"
-    "github.com/fabric8-services/fabric8-wit/log"
+	"github.com/fabric8-services/fabric8-wit/log"
 )
 
 type FilterFunc func(map[interface{}]interface{}) bool

--- a/openshift/process_template.go
+++ b/openshift/process_template.go
@@ -10,7 +10,8 @@ import (
 
 	"github.com/fabric8-services/fabric8-tenant/toggles"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
-	"github.com/fabric8-services/fabric8-wit/log"
+	jwt "github.com/dgrijalva/jwt-go"
+    "github.com/fabric8-services/fabric8-wit/log"
 )
 
 type FilterFunc func(map[interface{}]interface{}) bool
@@ -136,7 +137,7 @@ func LoadProcessedTemplates(ctx context.Context, config Config, username string,
 		if token != nil {
 			vars["OSIO_TOKEN"] = token.Raw
 			id := token.Claims.(jwt.MapClaims)["sub"]
-			if token != nil {
+			if id != nil {
 				vars["IDENTITY_ID"] = id
 			}
 		}

--- a/openshift/process_template.go
+++ b/openshift/process_template.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/fabric8-services/fabric8-tenant/toggles"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
+	"github.com/fabric8-services/fabric8-wit/log"
 )
 
 type FilterFunc func(map[interface{}]interface{}) bool
@@ -134,7 +135,12 @@ func LoadProcessedTemplates(ctx context.Context, config Config, username string,
 		token := goajwt.ContextJWT(ctx)
 		if token != nil {
 			vars["OSIO_TOKEN"] = token.Raw
+			id := token.Claims.(jwt.MapClaims)["sub"]
+			if token != nil {
+				vars["IDENTITY_ID"] = id
+			}
 		}
+		vars["REQUEST_ID"] = log.ExtractRequestID(ctx)
 		cheType = "mt-"
 	}
 

--- a/openshift/process_template.go
+++ b/openshift/process_template.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fabric8-services/fabric8-tenant/toggles"
 	"github.com/fabric8-services/fabric8-wit/log"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
+	"github.com/pkg/errors"
 )
 
 type FilterFunc func(map[interface{}]interface{}) bool

--- a/openshift/process_template.go
+++ b/openshift/process_template.go
@@ -8,10 +8,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/fabric8-services/fabric8-tenant/toggles"
-	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/fabric8-services/fabric8-tenant/toggles"
 	"github.com/fabric8-services/fabric8-wit/log"
+	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 )
 
 type FilterFunc func(map[interface{}]interface{}) bool

--- a/openshift/process_template.go
+++ b/openshift/process_template.go
@@ -138,7 +138,7 @@ func LoadProcessedTemplates(ctx context.Context, config Config, username string,
 			vars["OSIO_TOKEN"] = token.Raw
 			id := token.Claims.(jwt.MapClaims)["sub"]
 			if id != nil {
-				vars["IDENTITY_ID"] = id
+				vars["IDENTITY_ID"] = id.(string)
 			}
 		}
 		vars["REQUEST_ID"] = log.ExtractRequestID(ctx)

--- a/openshift/process_template.go
+++ b/openshift/process_template.go
@@ -137,9 +137,10 @@ func LoadProcessedTemplates(ctx context.Context, config Config, username string,
 		if token != nil {
 			vars["OSIO_TOKEN"] = token.Raw
 			id := token.Claims.(jwt.MapClaims)["sub"]
-			if id != nil {
-				vars["IDENTITY_ID"] = id.(string)
+			if id == nil {
+				return nil, errors.New("Missing sub in JWT token")
 			}
+			vars["IDENTITY_ID"] = id.(string)
 		}
 		vars["REQUEST_ID"] = log.ExtractRequestID(ctx)
 		cheType = "mt-"

--- a/template/generate_test.go
+++ b/template/generate_test.go
@@ -102,7 +102,7 @@ func TestFoundCheMultiTenant(t *testing.T) {
 		t.Fatalf("parameters not found")
 	}
 
-	assert.Equal(t, 5, len(params), "unknown number of parameters")
+	assert.Equal(t, 3, len(params), "unknown number of parameters")
 }
 
 func TestFoundCheQuotasOSO(t *testing.T) {

--- a/template/generate_test.go
+++ b/template/generate_test.go
@@ -102,7 +102,7 @@ func TestFoundCheMultiTenant(t *testing.T) {
 		t.Fatalf("parameters not found")
 	}
 
-	assert.Equal(t, 3, len(params), "unknown number of parameters")
+	assert.Equal(t, 5, len(params), "unknown number of parameters")
 }
 
 func TestFoundCheQuotasOSO(t *testing.T) {


### PR DESCRIPTION
These 2 values should be added to the config map that will be read by the run-once POD that will do the single-tenant to multi-tenant migration.

This PR is a followup of this one: https://github.com/fabric8-services/fabric8-tenant-che/pull/74/files and should be merged one the latter is merged