### PR TITLE
Call /api/users/id to avoid endless loop with auth

### DIFF
--- a/controller/tenant.go
+++ b/controller/tenant.go
@@ -63,7 +63,7 @@ func (c *TenantController) Setup(ctx *app.SetupTenantContext) error {
 	}
 
 	// fetch the cluster the user belongs to
-	user, err := c.userService.CurrentUser(ctx, userToken.Raw)
+	user, err := c.userService.Get(ctx, ttoken.Subject())
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
@@ -131,7 +131,7 @@ func (c *TenantController) Update(ctx *app.UpdateTenantContext) error {
 	}
 
 	// fetch the cluster the user belongs to
-	user, err := c.userService.CurrentUser(ctx, userToken.Raw)
+	user, err := c.userService.Get(ctx, ttoken.Subject())
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
@@ -182,9 +182,10 @@ func (c *TenantController) Clean(ctx *app.CleanTenantContext) error {
 	if userToken == nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("Missing JWT token"))
 	}
+	ttoken := &TenantToken{token: userToken}
 
 	// fetch the cluster the user belongs to
-	user, err := c.userService.CurrentUser(ctx, userToken.Raw)
+	user, err := c.userService.Get(ctx, ttoken.Subject())
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}

--- a/main.go
+++ b/main.go
@@ -131,7 +131,7 @@ func main() {
 		config.GetTokenKey())
 
 	// create user profile client to get the user's cluster
-	userService := token.NewAuthUserServiceClient(config)
+	userService := token.NewAuthUserServiceClient(config, saToken)
 
 	var tr *http.Transport
 	if config.APIServerInsecureSkipTLSVerify() {

--- a/token/auth_service_account.go
+++ b/token/auth_service_account.go
@@ -91,6 +91,17 @@ func CreateClient(config AuthClientConfig) (*auth.Client, error) {
 	return c, nil
 }
 
+func CreateCustomClient(config AuthClientConfig, custom goaclient.Doer) (*auth.Client, error) {
+	u, err := url.Parse(config.GetAuthURL())
+	if err != nil {
+		return nil, err
+	}
+	c := auth.New(custom)
+	c.Host = u.Host
+	c.Scheme = u.Scheme
+	return c, nil
+}
+
 // validateError function when given client and response checks if the
 // response has any errors by also looking at the status code
 func validateError(c *auth.Client, res *http.Response) error {


### PR DESCRIPTION
auth /api/user calls tenant setup calls auth /api/user...

Related to openshiftio/openshift.io#1687