### PR TITLE
Expose basic go runtime metrics via Prometheus

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -28,6 +28,7 @@ const (
 	varPostgresConnectionMaxIdle       = "postgres.connection.maxidle"
 	varPostgresConnectionMaxOpen       = "postgres.connection.maxopen"
 	varHTTPAddress                     = "http.address"
+	varMetricsHTTPAddress              = "metrics.http.address"
 	varDeveloperModeEnabled            = "developer.mode.enabled"
 	varKeycloakClientID                = "keycloak.client.id"
 	varKeycloakRealm                   = "keycloak.realm"
@@ -115,6 +116,7 @@ func (c *Data) setConfigDefaults() {
 	// HTTP
 	//-----
 	c.v.SetDefault(varHTTPAddress, "0.0.0.0:8080")
+	c.v.SetDefault(varMetricsHTTPAddress, "0.0.0.0:8080")
 
 	//-----
 	// Misc
@@ -208,6 +210,12 @@ func (c *Data) GetPostgresConfigString() string {
 // that the alm server binds to (e.g. "0.0.0.0:8080")
 func (c *Data) GetHTTPAddress() string {
 	return c.v.GetString(varHTTPAddress)
+}
+
+// GetMetricsHTTPAddress returns the address the /metrics endpoing will be mounted.
+// By default GetMetricsHTTPAddress is the same as GetHTTPAddress
+func (c *Data) GetMetricsHTTPAddress() string {
+	return c.v.GetString(varMetricsHTTPAddress)
 }
 
 // IsDeveloperModeEnabled returns if development related features (as set via default, config file, or environment variable),

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,20 @@
-hash: 11d7ed58d948b60118aa58f7e7d2d71d8f2d231f507c2d3d3d318bf6dcbab9c7
-updated: 2017-11-12T00:05:38.194370944+01:00
+hash: c3b517bed13f23c18b32e9d92d1a6555e99fd025d7eeb6d6d055e4ee0221daf6
+updated: 2018-01-27T03:06:02.770020823+01:00
 imports:
 - name: github.com/ajg/form
   version: cc2954064ec9ea8d93917f0f87456e11d7b881ad
 - name: github.com/armon/go-metrics
   version: 9a4b6e10bed6220a1665955aa2b75afc91eb10b3
+- name: github.com/beorn7/perks
+  version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
+  subpackages:
+  - quantile
 - name: github.com/bitly/go-simplejson
   version: aabad6e819789e569bd6aabf444c935aa9ba1e44
+- name: github.com/davecgh/go-spew
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  subpackages:
+  - spew
 - name: github.com/dgrijalva/jwt-go
   version: dbeaa9332f19a944acb5736b4456cfcc02140e29
 - name: github.com/dimfeld/httppath
@@ -20,7 +28,6 @@ imports:
 - name: github.com/fabric8-services/fabric8-auth
   version: f67317193c3108895f853f80f9330c1a65b11004
   subpackages:
-  - configuration
   - design
   - errors
   - log
@@ -39,7 +46,7 @@ imports:
   - resource
   - rest
 - name: github.com/fsnotify/fsnotify
-  version: 629574ca2a5df945712d3079857300b5e4da0236
+  version: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
 - name: github.com/fzipp/gocyclo
   version: 6acd4345c835499920e8426c7e4e8d7a34f1bb83
 - name: github.com/goadesign/goa
@@ -67,6 +74,12 @@ imports:
   version: c7bacac2b21ca01afa1dee0acf64df3ce047c28f
   subpackages:
   - golint
+- name: github.com/golang/protobuf
+  version: 8ee79997227bf9b34611aee7946ae64735e6fd93
+  subpackages:
+  - proto
+- name: github.com/google/go-querystring
+  version: 9235644dd9e52eeae6fa48efd539fdc351a0af53
 - name: github.com/hashicorp/go-immutable-radix
   version: 8aac2701530899b64bdea735a1de8da899815220
 - name: github.com/hashicorp/golang-lru
@@ -97,9 +110,13 @@ imports:
   subpackages:
   - oid
 - name: github.com/magiconair/properties
-  version: be5ece7dd465ab0765a9682137865547526d1dfb
+  version: d419a98cdbed11a922bf76f257b7c4be79b50e73
 - name: github.com/manveru/faker
   version: 717f7cf83fb78669bfab612749c2e8ff63d5be11
+- name: github.com/matttproud/golang_protobuf_extensions
+  version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
+  subpackages:
+  - pbutil
 - name: github.com/mitchellh/mapstructure
   version: 5a0325d7fafaac12dda6e7fb8bd222ec1b69875e
 - name: github.com/pelletier/go-buffruneio
@@ -108,8 +125,28 @@ imports:
   version: 13d49d4606eb801b8f01ae542b4afc4c6ee3d84a
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
+- name: github.com/prometheus/client_golang
+  version: e51041b3fa41cece0dca035740ba6411905be473
+  subpackages:
+  - prometheus
+- name: github.com/prometheus/client_model
+  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
+  subpackages:
+  - go
+- name: github.com/prometheus/common
+  version: a6ab08426bb262e2d190097751f5cfd1cfdfd17d
+  subpackages:
+  - expfmt
+  - internal/bitbucket.org/ww/goautoneg
+  - model
+- name: github.com/prometheus/procfs
+  version: 454a56f35412459b5e684fd5ec0f9211b94f002a
 - name: github.com/satori/go.uuid
-  version: b061729afc07e77a8aa4fad0a2fd840958f1942a
+  version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/sirupsen/logrus
   version: c078b1e43f58d563c74cebe63c85789e76ddb627
 - name: github.com/spf13/afero
@@ -127,19 +164,32 @@ imports:
 - name: github.com/spf13/viper
   version: 651d9d916abc3c3d6a91a12549495caba5edffd2
 - name: github.com/stretchr/testify
-  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  version: b91bfb9ebec76498946beb6af7c0230c7cc7ba6c
   subpackages:
   - assert
   - require
+  - suite
 - name: github.com/Unleash/unleash-client-go
   version: 5e8fdebb43e3dd7a8d25c4614925122b06c2ede3
+  subpackages:
+  - context
+  - internal/api
+  - internal/strategies
+  - strategy
 - name: github.com/zach-klippenstein/goregen
   version: 795b5e3961ea1912fde60af417ad85e86acc0d6a
 - name: golang.org/x/crypto
   version: 81e90905daefcd6fd217b62423c0908922eadb30
   subpackages:
+  - cast5
   - ed25519
   - ed25519/internal/edwards25519
+  - openpgp
+  - openpgp/armor
+  - openpgp/elgamal
+  - openpgp/errors
+  - openpgp/packet
+  - openpgp/s2k
 - name: golang.org/x/net
   version: b1a2d6e8c8b5fc8f601ead62536f02a8e1b6217d
   subpackages:
@@ -166,15 +216,11 @@ imports:
 - name: gopkg.in/yaml.v2
   version: a5b47d31c556af34a302ce5d659e6fea44d90de0
 testImports:
-- name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
-  subpackages:
-  - spew
+- name: github.com/certifi/gocertifi
+  version: deb3ae2ef2610fde3330947281941c562861188b
+- name: github.com/getsentry/raven-go
+  version: 563b81fc02b75d664e54da31f787c2cc2186780b
 - name: github.com/jstemmer/go-junit-report
   version: 15422cf504f9dc030386499a5c68053a38763e58
-- name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
-  subpackages:
-  - difflib
 - name: github.com/wadey/gocovmerge
   version: b5bfa59ec0adc420475f97f89b58045c721d761c

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: github.com/dgrijalva/jwt-go
   version: ^3.0.0
 - package: github.com/goadesign/goa
-  version: ^1.3.0
+  version: v1.3.0
   vcs: git
   subpackages:
   - client
@@ -40,6 +40,7 @@ import:
 - package: github.com/spf13/cobra
 - package: github.com/spf13/viper
 - package: github.com/Unleash/unleash-client-go
+- package: github.com/prometheus/client_golang
 - package: github.com/golang/lint
   subpackages:
   - golint
@@ -62,6 +63,7 @@ import:
   subpackages:
   - go/ast/astutil
 - package: github.com/satori/go.uuid
+  version: v1.1.0
 - package: github.com/bitly/go-simplejson
   version: ^0.5.0
 - package: github.com/google/go-querystring


### PR DESCRIPTION
Metrics are exposed under /metrics and the used port
can be controlled via F8_METRICS_HTTP_ADDRESS. By
default same port as F8_HTTP_ADDRESS is used.