### PR TITLE
Use whitelist to restrict permission to user profile override

### DIFF
--- a/controller/tenant.go
+++ b/controller/tenant.go
@@ -285,6 +285,9 @@ func usersOpenshiftConfig(osTemplate openshift.Config, user *auth.UserDataAttrib
 }
 
 func overrideTemplateVersions(user *auth.UserDataAttributes, config openshift.Config) openshift.Config {
+	if user.FeatureLevel != nil && *user.FeatureLevel != "internal" {
+		return config
+	}
 	userContext := user.ContextInformation
 	if tc, found := userContext["tenantConfig"]; found {
 		if tenantConfig, ok := tc.(map[string]interface{}); ok {

--- a/controller/tenant_test.go
+++ b/controller/tenant_test.go
@@ -1,0 +1,91 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/fabric8-services/fabric8-tenant/auth"
+	"github.com/fabric8-services/fabric8-tenant/openshift"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTenantOverride(t *testing.T) {
+	internalFeatureLevel := "internal"
+	otherFeatureLevel := "producation"
+	openshiftConfig := openshift.Config{
+		CheVersion:     "che-version",
+		JenkinsVersion: "jenkins-version",
+		MavenRepoURL:   "maven-url",
+		TeamVersion:    "team-version",
+	}
+
+	t.Run("override disabled", func(t *testing.T) {
+
+		t.Run("external user with config", func(t *testing.T) {
+			// given
+			user := &auth.UserDataAttributes{
+				ContextInformation: map[string]interface{}{
+					"tenantConfig": map[string]interface{}{
+						"cheVersion":     "another-che-version",
+						"jenkinsVersion": "another-jenkins-version",
+						"teamVersion":    "another-team-version",
+						"mavenRepo":      "another-maven-url",
+					},
+				},
+				FeatureLevel: &otherFeatureLevel,
+			}
+			// when
+			resultConfig := overrideTemplateVersions(user, openshiftConfig)
+			// then
+			assert.Equal(t, openshiftConfig, resultConfig)
+		})
+
+		t.Run("external user without config", func(t *testing.T) {
+			// given
+			user := &auth.UserDataAttributes{}
+			// when
+			resultConfig := overrideTemplateVersions(user, openshiftConfig)
+			// then
+			assert.Equal(t, openshiftConfig, resultConfig)
+		})
+	})
+
+	t.Run("override enabled", func(t *testing.T) {
+
+		t.Run("internal user with config", func(t *testing.T) {
+			// given
+			user := &auth.UserDataAttributes{
+				ContextInformation: map[string]interface{}{
+					"tenantConfig": map[string]interface{}{
+						"cheVersion":     "another-che-version",
+						"jenkinsVersion": "another-jenkins-version",
+						"teamVersion":    "another-team-version",
+						"mavenRepo":      "another-maven-url",
+					},
+				},
+				FeatureLevel: &internalFeatureLevel,
+			}
+			// when
+			resultConfig := overrideTemplateVersions(user, openshiftConfig)
+			// then
+			expectedOpenshiftConfig := openshift.Config{
+				CheVersion:     "another-che-version",
+				JenkinsVersion: "another-jenkins-version",
+				MavenRepoURL:   "another-maven-url",
+				TeamVersion:    "another-team-version",
+			}
+			assert.Equal(t, expectedOpenshiftConfig, resultConfig)
+		})
+
+		t.Run("internal user without config", func(t *testing.T) {
+			// given
+			user := &auth.UserDataAttributes{
+				FeatureLevel: &internalFeatureLevel,
+			}
+			// when
+			resultConfig := overrideTemplateVersions(user, openshiftConfig)
+			// then
+			assert.Equal(t, openshiftConfig, resultConfig)
+		})
+	})
+
+}


### PR DESCRIPTION
Only certain users should have access to override the tenant
profile in production. Locked down to the feature group internal.

Fixes #495