### PR TITLE
Disable 'pullForce=true' when retrieving cluster SA token (OSIO#2304)

### DIFF
--- a/cluster/service.go
+++ b/cluster/service.go
@@ -81,7 +81,7 @@ func (s *clusterService) GetClusters(ctx context.Context) ([]*Cluster, error) {
 
 	var cls []*Cluster
 	for _, cluster := range clusters.Data {
-		clusterUser, clusterToken, err := s.resolveToken(ctx, cluster.APIURL, s.serviceToken, true, s.decode) // use "forcePull=true" to validate the `tenant service account` token on the target
+		clusterUser, clusterToken, err := s.resolveToken(ctx, cluster.APIURL, s.serviceToken, false, s.decode) // can't use "forcePull=true" to validate the `tenant service account` token since it's encrypted on auth
 		if err != nil {
 			return nil, errors.Wrapf(err, "Unable to resolve token for cluster %v", cluster.APIURL)
 		}

--- a/test/data/cluster/resolve_cluster.yaml
+++ b/test/data/cluster/resolve_cluster.yaml
@@ -3,7 +3,7 @@ version: 1
 interactions:
 - request:
     method: GET
-    url: http://authservice/api/token?for=some_valid_openshift_resource&force_pull=true
+    url: http://authservice/api/token?for=some_valid_openshift_resource&force_pull=false
     headers:
       sub: ["tenant_service"] # will be compared against the `sub` claim in the incoming request's token
   response:
@@ -35,7 +35,7 @@ interactions:
     }'
 - request:
     method: GET
-    url: http://authservice/api/token?for=http%3A%2F%2Fcluster%2Fapi&force_pull=true
+    url: http://authservice/api/token?for=http%3A%2F%2Fcluster%2Fapi&force_pull=false
     headers:
       sub: ["tenant_service"] # will be compared against the `sub` claim in the incoming request's token
   response:


### PR DESCRIPTION
`auth-service` stores the clusters' service account tokens in an encrypted
form and it cannot decrypt them (only `tenant-service` can do it), so it
is not able to validate the tokens. This will have to be done by the
`tenant-service` once the cluster tokens have been retrieved and
decoded.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>