### PR TITLE
Revert "Log requested update template"

### DIFF
--- a/controller/tenant.go
+++ b/controller/tenant.go
@@ -20,6 +20,7 @@ import (
 	"github.com/goadesign/goa"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 	uuid "github.com/satori/go.uuid"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // TenantController implements the status resource.
@@ -287,8 +288,8 @@ func InitTenant(ctx context.Context, masterURL string, service tenant.Service, c
 			"namespace": openshift.GetNamespace(request),
 			"name":      openshift.GetName(request),
 			"kind":      openshift.GetKind(request),
-			"request":   openshift.YamlString(request),
-			"response":  openshift.YamlString(response),
+			"request":   yamlString(request),
+			"response":  yamlString(response),
 		}, "resource requested")
 		if statusCode == http.StatusConflict {
 			if openshift.GetKind(request) == openshift.ValKindNamespace {
@@ -358,8 +359,8 @@ func InitTenant(ctx context.Context, masterURL string, service tenant.Service, c
 			"namespace": openshift.GetNamespace(request),
 			"name":      openshift.GetName(request),
 			"kind":      openshift.GetKind(request),
-			"request":   openshift.YamlString(request),
-			"response":  openshift.YamlString(response),
+			"request":   yamlString(request),
+			"response":  yamlString(response),
 		}, "unhandled resource response")
 		return "", nil
 	}
@@ -440,4 +441,12 @@ func convertTenant(ctx context.Context, tenant *tenant.Tenant, namespaces []*ten
 			})
 	}
 	return &result
+}
+
+func yamlString(data map[interface{}]interface{}) string {
+	b, err := yaml.Marshal(data)
+	if err != nil {
+		return fmt.Sprintf("Could not marshal yaml %v", data)
+	}
+	return string(b)
 }

--- a/openshift/apply.go
+++ b/openshift/apply.go
@@ -475,12 +475,3 @@ func (a ByKind) Less(i, j int) bool {
 	}
 	return iO < jO
 }
-
-// YamlString returns a Yaml object to String
-func YamlString(data map[interface{}]interface{}) string {
-	b, err := yaml.Marshal(data)
-	if err != nil {
-		return fmt.Sprintf("Could not marshal yaml %v", data)
-	}
-	return string(b)
-}

--- a/openshift/init_tenant.go
+++ b/openshift/init_tenant.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/fabric8-services/fabric8-tenant/tenant"
 	"github.com/fabric8-services/fabric8-wit/log"
+	yaml "gopkg.in/yaml.v2"
 )
 
 const (
@@ -117,19 +118,19 @@ func RawUpdateTenant(ctx context.Context, config Config, callback Callback, user
 	for key, val := range mapped {
 		go func(namespace string, objects []map[interface{}]interface{}, opts ApplyOptions) {
 			defer wg.Done()
-			template := listToTemplate(
-				Filter(
-					objects,
-					IsNotOfKind(ValKindProjectRequest),
-				),
-			)
 			output, err := executeProccessedNamespaceCMD(
-				template,
+				listToTemplate(
+					//RemoveReplicas(
+					Filter(
+						objects,
+						IsNotOfKind(ValKindProjectRequest),
+					),
+					//),
+				),
 				opts.WithNamespace(namespace),
 			)
 			if err != nil {
 				log.Error(ctx, map[string]interface{}{
-					"request":   template,
 					"output":    output,
 					"namespace": namespace,
 					"error":     err,
@@ -137,7 +138,6 @@ func RawUpdateTenant(ctx context.Context, config Config, callback Callback, user
 				return
 			}
 			log.Info(ctx, map[string]interface{}{
-				"request":   template,
 				"output":    output,
 				"namespace": namespace,
 			}, "applied")
@@ -154,5 +154,6 @@ func listToTemplate(objects []map[interface{}]interface{}) string {
 		"objects":    objects,
 	}
 
-	return YamlString(template)
+	b, _ := yaml.Marshal(template)
+	return string(b)
 }


### PR DESCRIPTION
Jenkins template is too large for the fluentd log monitor to consume as 1 line which splits up the log line over 4 lines. 

Reverts fabric8-services/fabric8-tenant#562