### PR TITLE
Set resource limits on Container level

### DIFF
--- a/OpenShiftTemplate.yml
+++ b/OpenShiftTemplate.yml
@@ -16,9 +16,6 @@ objects:
       app: f8tenant
       deploymentconfig: f8tenant
     strategy:
-      resources:
-        limits:
-          memory: 1Gi
       rollingParams:
         intervalSeconds: 1
         maxSurge: 25%
@@ -146,6 +143,9 @@ objects:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
+          resources:
+            limits:
+              memory: 1Gi            
     triggers:
     - type: ConfigChange
 - apiVersion: v1


### PR DESCRIPTION
Restrict how much memory the container can consume.

Limit to avoid it overtaking the cluster if the process were to go rogue.

Related to openshiftio/openshift.io#2685