### PR TITLE
move COPY cmds in Dockerfile.deploy to end

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -15,9 +15,6 @@ RUN cd /tmp \
     && mv openshift-origin*/oc /usr/bin \
     && rm -rfv openshift-origin*
 
-COPY bin/fabric8-tenant ${INSTALL_PREFIX}/bin/fabric8-tenant
-RUN mkdir ${KUBECONFIG_DIR} && chmod +777 ${KUBECONFIG_DIR}
-
 # Install little pcp pmcd server for metrics collection
 # would prefer only pmcd, and not the /bin/pm*tools etc.
 COPY pcp.repo /etc/yum.repos.d/pcp.repo
@@ -28,6 +25,8 @@ RUN yum install -y pcp pcp-pmda-prometheus && yum clean all && \
 COPY ./tenant+pmcd.sh /tenant+pmcd.sh
 EXPOSE 44321
             
+COPY bin/fabric8-tenant ${INSTALL_PREFIX}/bin/fabric8-tenant
+RUN mkdir ${KUBECONFIG_DIR} && chmod +777 ${KUBECONFIG_DIR}
 
 # From here onwards, any RUN, CMD, or ENTRYPOINT will be run under the following user
 USER ${F8_USER_NAME}


### PR DESCRIPTION
This will help reduce build cycle while doing development in
containers.

Right now the way COPY commands are placed require all subsequent layers to
be built everytime the image is built. Which has a time consuming yum
install as well.