### PR TITLE
Include tenant id in "Not found" error response (#573)

### DIFF
--- a/auth/auth_client.go
+++ b/auth/auth_client.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/fabric8-services/fabric8-auth/errors"
+
 	authclient "github.com/fabric8-services/fabric8-tenant/auth/client"
 	"github.com/fabric8-services/fabric8-tenant/configuration"
 	"github.com/fabric8-services/fabric8-wit/log"
@@ -51,21 +53,27 @@ func (d *doer) Do(ctx context.Context, req *http.Request) (*http.Response, error
 
 // ValidateResponse function when given client and response checks if the
 // response has any errors by also looking at the status code
-func ValidateResponse(c *authclient.Client, res *http.Response) error {
-	if res.StatusCode == http.StatusNotFound {
-		return fmt.Errorf("resource not found")
-	} else if res.StatusCode != http.StatusOK {
-		goaErr, err := c.DecodeJSONAPIErrors(res)
-		if err != nil {
-			return err
-		}
-		if len(goaErr.Errors) != 0 {
-			var output string
-			for _, error := range goaErr.Errors {
-				output += fmt.Sprintf("%s: %s %s, %s\n", *error.Title, *error.Status, *error.Code, error.Detail)
-			}
-			return fmt.Errorf("%s", output)
-		}
+func ValidateResponse(ctx context.Context, c *authclient.Client, res *http.Response) error {
+	// 2xx and 3xx response are not considered as errors
+	if res.StatusCode < 400 {
+		return nil
 	}
-	return nil
+	errs, err := c.DecodeJSONAPIErrors(res)
+	if err != nil {
+		return err
+	}
+	if len(errs.Errors) > 0 {
+		if res.StatusCode == http.StatusNotFound {
+			// take the first JSON-API error and convert it into a NotFoundError
+			if errs.Errors[0].ID != nil {
+				return errors.NewNotFoundError("users", *errs.Errors[0].ID)
+			}
+		}
+		var output string
+		for _, error := range errs.Errors {
+			output += fmt.Sprintf("%s: %s %s, %s\n", *error.Title, *error.Status, *error.Code, error.Detail)
+		}
+		return errors.NewInternalError(ctx, fmt.Errorf("%s", output))
+	}
+	return errors.NewInternalError(ctx, fmt.Errorf("unknown error: %d", res.StatusCode))
 }

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -72,7 +72,7 @@ func (s *clusterService) GetClusters(ctx context.Context) ([]*Cluster, error) {
 		res.Body.Close()
 	}()
 
-	validationerror := auth.ValidateResponse(client, res)
+	validationerror := auth.ValidateResponse(ctx, client, res)
 	if validationerror != nil {
 		return nil, errors.Wrapf(validationerror, "error from server %q", s.authURL)
 	}

--- a/jsonapi/jsonapi_utility.go
+++ b/jsonapi/jsonapi_utility.go
@@ -37,11 +37,12 @@ func ErrorToJSONAPIError(ctx context.Context, err error) (app.JSONAPIError, int)
 	var statusCode int
 	var id *string
 	log.Error(ctx, map[string]interface{}{"err": cause, "error_message": cause.Error()}, "an error occurred in our api")
-	switch cause.(type) {
+	switch cause := cause.(type) {
 	case errors.NotFoundError:
 		code = ErrorCodeNotFound
 		title = "Not found error"
 		statusCode = http.StatusNotFound
+		id = &cause.ID
 	case errors.ConversionError:
 		code = ErrorCodeConversionError
 		title = "Conversion error"
@@ -74,8 +75,7 @@ func ErrorToJSONAPIError(ctx context.Context, err error) (app.JSONAPIError, int)
 		code = ErrorCodeUnknownError
 		title = "Unknown error"
 		statusCode = http.StatusInternalServerError
-
-		cause := errs.Cause(err)
+		cause = errs.Cause(err)
 		if err, ok := cause.(goa.ServiceError); ok {
 			statusCode = err.ResponseStatus()
 			idStr := err.Token()

--- a/jsonapi/jsonapi_utility_blackbox_test.go
+++ b/jsonapi/jsonapi_utility_blackbox_test.go
@@ -26,55 +26,57 @@ func TestErrorToJSONAPIError(t *testing.T) {
 	jerr, httpStatus = jsonapi.ErrorToJSONAPIError(nil, errors.NewNotFoundError("foo", "bar"))
 	require.Equal(t, http.StatusNotFound, httpStatus)
 	require.NotNil(t, jerr.Code)
-	require.NotNil(t, jerr.Status)
 	require.Equal(t, jsonapi.ErrorCodeNotFound, *jerr.Code)
+	require.NotNil(t, jerr.Status)
 	require.Equal(t, strconv.Itoa(httpStatus), *jerr.Status)
+	require.NotNil(t, jerr.ID)
+	require.Equal(t, "bar", *jerr.ID)
 
 	// test not found error
 	jerr, httpStatus = jsonapi.ErrorToJSONAPIError(nil, errors.NewConversionError("foo"))
 	require.Equal(t, http.StatusBadRequest, httpStatus)
 	require.NotNil(t, jerr.Code)
-	require.NotNil(t, jerr.Status)
 	require.Equal(t, jsonapi.ErrorCodeConversionError, *jerr.Code)
+	require.NotNil(t, jerr.Status)
 	require.Equal(t, strconv.Itoa(httpStatus), *jerr.Status)
 
 	// test bad parameter error
 	jerr, httpStatus = jsonapi.ErrorToJSONAPIError(nil, errors.NewBadParameterError("foo", "bar"))
 	require.Equal(t, http.StatusBadRequest, httpStatus)
 	require.NotNil(t, jerr.Code)
-	require.NotNil(t, jerr.Status)
 	require.Equal(t, jsonapi.ErrorCodeBadParameter, *jerr.Code)
+	require.NotNil(t, jerr.Status)
 	require.Equal(t, strconv.Itoa(httpStatus), *jerr.Status)
 
 	// test internal server error
 	jerr, httpStatus = jsonapi.ErrorToJSONAPIError(nil, errors.NewInternalError(context.Background(), errs.New("foo")))
 	require.Equal(t, http.StatusInternalServerError, httpStatus)
 	require.NotNil(t, jerr.Code)
-	require.NotNil(t, jerr.Status)
 	require.Equal(t, jsonapi.ErrorCodeInternalError, *jerr.Code)
+	require.NotNil(t, jerr.Status)
 	require.Equal(t, strconv.Itoa(httpStatus), *jerr.Status)
 
 	// test unauthorized error
 	jerr, httpStatus = jsonapi.ErrorToJSONAPIError(nil, errors.NewUnauthorizedError("foo"))
 	require.Equal(t, http.StatusUnauthorized, httpStatus)
 	require.NotNil(t, jerr.Code)
-	require.NotNil(t, jerr.Status)
 	require.Equal(t, jsonapi.ErrorCodeUnauthorizedError, *jerr.Code)
+	require.NotNil(t, jerr.Status)
 	require.Equal(t, strconv.Itoa(httpStatus), *jerr.Status)
 
 	// test forbidden error
 	jerr, httpStatus = jsonapi.ErrorToJSONAPIError(nil, errors.NewForbiddenError("foo"))
 	require.Equal(t, http.StatusForbidden, httpStatus)
 	require.NotNil(t, jerr.Code)
-	require.NotNil(t, jerr.Status)
 	require.Equal(t, jsonapi.ErrorCodeForbiddenError, *jerr.Code)
+	require.NotNil(t, jerr.Status)
 	require.Equal(t, strconv.Itoa(httpStatus), *jerr.Status)
 
 	// test unspecified error
 	jerr, httpStatus = jsonapi.ErrorToJSONAPIError(nil, fmt.Errorf("foobar"))
 	require.Equal(t, http.StatusInternalServerError, httpStatus)
 	require.NotNil(t, jerr.Code)
-	require.NotNil(t, jerr.Status)
 	require.Equal(t, jsonapi.ErrorCodeUnknownError, *jerr.Code)
+	require.NotNil(t, jerr.Status)
 	require.Equal(t, strconv.Itoa(httpStatus), *jerr.Status)
 }

--- a/token/sa_service.go
+++ b/token/sa_service.go
@@ -60,7 +60,7 @@ func (s *serviceAccountTokenService) GetOAuthToken(ctx context.Context) (*string
 		res.Body.Close()
 	}()
 
-	validationerror := auth.ValidateResponse(c, res)
+	validationerror := auth.ValidateResponse(ctx, c, res)
 	if validationerror != nil {
 		return nil, errors.Wrapf(validationerror, "error from server %q", s.config.GetAuthURL())
 	}

--- a/token/service.go
+++ b/token/service.go
@@ -41,7 +41,7 @@ func (s *tokenService) ResolveTargetToken(ctx context.Context, target, token str
 		res.Body.Close()
 	}()
 
-	err = auth.ValidateResponse(client, res)
+	err = auth.ValidateResponse(ctx, client, res)
 	if err != nil {
 		return "", "", errors.Wrapf(err, "error while resolving the token for %s", target)
 	}

--- a/user/user_service.go
+++ b/user/user_service.go
@@ -45,7 +45,7 @@ func (s *userService) GetUser(ctx context.Context, id uuid.UUID) (*authclient.Us
 	}
 	defer res.Body.Close()
 
-	validationerror := auth.ValidateResponse(c, res)
+	validationerror := auth.ValidateResponse(ctx, c, res)
 	if validationerror != nil {
 		return nil, errors.Wrapf(validationerror, "error from server %q", s.authURL)
 	}


### PR DESCRIPTION
Set the JSON-API error `ID` with the `NotFoundError.ID` value.

Fixes #573

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>