### PR TITLE
Skip the build on the second time the script is run

### DIFF
--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -2,8 +2,15 @@
 
 . cico_setup.sh
 
-cico_setup;
+load_jenkins_vars
 
-run_tests_without_coverage;
+if [ ! -f .cico-prepare ]; then
+    install_deps
+    prepare
+
+    run_tests_without_coverage
+
+    touch .cico-prepare
+fi
 
 deploy;


### PR DESCRIPTION
The build script is being run twice, one to build the CentOS container. The second one for the RHEL container.

On the second run, it fails:

```
Docker container "fabric8-tenant-local-build" already exists. To recreate, run "make docker-rm".
+ make docker-check-go-format
docker exec -t -i "fabric8-tenant-local-build" bash -ec 'make check-go-format'
ERROR: These files differ from gofmt's style (run 'make format-go-code' to fix this):
./migration/sqlbindata.go
make: *** [check-go-format] Error 1
```

It is completely unnecessary to run through the steps twice. That's why in this commit the preparation steps are only executed if they haven't been executed before.