### PR TITLE
API to delete/deprovision a user from Tenant (OSIO#3338)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,15 +2,10 @@
 
 
 [[projects]]
+  branch = "master"
   name = "github.com/Unleash/unleash-client-go"
-  packages = [
-    ".",
-    "context",
-    "internal/api",
-    "internal/strategies",
-    "strategy"
-  ]
-  revision = "5e8fdebb43e3dd7a8d25c4614925122b06c2ede3"
+  packages = [".","context","internal/api","internal/strategies","strategy"]
+  revision = "be883ea1af714aff427d0668dbd4fc549d4f701c"
 
 [[projects]]
   name = "github.com/ajg/form"
@@ -19,14 +14,16 @@
   version = "v1.5"
 
 [[projects]]
+  branch = "master"
   name = "github.com/armon/go-metrics"
   packages = ["."]
-  revision = "9a4b6e10bed6220a1665955aa2b75afc91eb10b3"
+  revision = "783273d703149aaeb9897cf58613d5af48861c25"
 
 [[projects]]
+  branch = "master"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
-  revision = "3ac7bf7a47d159a033b107610db8a1b6575507a4"
+  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -36,51 +33,37 @@
 
 [[projects]]
   name = "github.com/dgrijalva/jwt-go"
-  packages = [
-    ".",
-    "request"
-  ]
-  revision = "dbeaa9332f19a944acb5736b4456cfcc02140e29"
-  version = "v3.1.0"
+  packages = [".","request"]
+  revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
+  version = "v3.2.0"
 
 [[projects]]
+  branch = "master"
   name = "github.com/dimfeld/httppath"
   packages = ["."]
-  revision = "c8e499c3ef3c3e272ed8bdcc1ccf39f73c88debc"
+  revision = "ee938bf735983d53694d79138ad9820efff94c92"
 
 [[projects]]
   name = "github.com/dimfeld/httptreemux"
   packages = ["."]
-  revision = "13dde8a00d96b369e7398490fd8a3af9ca114b84"
-  version = "v3.9.0"
+  revision = "7f532489e7739b3d49df5c602bf63549881fe753"
+  version = "v5.0.1"
 
 [[projects]]
   name = "github.com/dnaeon/go-vcr"
-  packages = [
-    "cassette",
-    "recorder"
-  ]
+  packages = ["cassette","recorder"]
   revision = "9d71b8a6df86e00127f96bc8dabc09856ab8afdb"
 
 [[projects]]
   name = "github.com/fabric8-services/fabric8-auth"
-  packages = [
-    "design",
-    "errors"
-  ]
+  packages = ["design","errors"]
   revision = "19eb16aaf10758299c4a5360600af983b8470909"
 
 [[projects]]
+  branch = "master"
   name = "github.com/fabric8-services/fabric8-wit"
-  packages = [
-    "configuration",
-    "errors",
-    "goamiddleware",
-    "log",
-    "resource",
-    "rest"
-  ]
-  revision = "ed49dd4d0678a97d13ba469efbd5cdea2e5dbe67"
+  packages = ["configuration","errors","goamiddleware","log","resource","rest"]
+  revision = "b59d0dc8ae9b2bfea1fb5dc6ff3552c42b735756"
 
 [[projects]]
   name = "github.com/fsnotify/fsnotify"
@@ -90,64 +73,33 @@
 
 [[projects]]
   name = "github.com/goadesign/goa"
-  packages = [
-    ".",
-    "client",
-    "cors",
-    "design",
-    "design/apidsl",
-    "dslengine",
-    "encoding/form",
-    "goagen",
-    "goagen/codegen",
-    "goagen/gen_app",
-    "goagen/gen_client",
-    "goagen/gen_controller",
-    "goagen/gen_main",
-    "goagen/gen_schema",
-    "goagen/gen_swagger",
-    "goagen/meta",
-    "goagen/utils",
-    "goatest",
-    "logging/logrus",
-    "middleware",
-    "middleware/gzip",
-    "middleware/security/jwt",
-    "uuid",
-    "version"
-  ]
+  packages = [".","client","cors","design","design/apidsl","dslengine","encoding/form","goagen","goagen/codegen","goagen/gen_app","goagen/gen_client","goagen/gen_controller","goagen/gen_main","goagen/gen_schema","goagen/gen_swagger","goagen/meta","goagen/utils","goatest","logging/logrus","middleware","middleware/gzip","middleware/security/jwt","uuid","version"]
   revision = "5646a430cdeb66983d5ace3384e0a667c185abc7"
   version = "v1.3.0"
 
 [[projects]]
   name = "github.com/golang/protobuf"
   packages = ["proto"]
-  revision = "8ee79997227bf9b34611aee7946ae64735e6fd93"
+  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
+  version = "v1.1.0"
 
 [[projects]]
+  branch = "master"
   name = "github.com/hashicorp/go-immutable-radix"
   packages = ["."]
-  revision = "8aac2701530899b64bdea735a1de8da899815220"
+  revision = "7f3cd4390caab3250a57f30efdb2a65dd7649ecf"
 
 [[projects]]
+  branch = "master"
   name = "github.com/hashicorp/golang-lru"
   packages = ["simplelru"]
-  revision = "0a025b7e63adc15a622f29b0b2c4c3848243bbf6"
+  revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
+  branch = "master"
   name = "github.com/hashicorp/hcl"
-  packages = [
-    ".",
-    "hcl/ast",
-    "hcl/parser",
-    "hcl/scanner",
-    "hcl/strconv",
-    "hcl/token",
-    "json/parser",
-    "json/scanner",
-    "json/token"
-  ]
-  revision = "37ab263305aaeb501a60eb16863e808d426e37f2"
+  packages = [".","hcl/ast","hcl/parser","hcl/printer","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
 
 [[projects]]
   name = "github.com/inconshreveable/mousetrap"
@@ -158,38 +110,31 @@
 [[projects]]
   name = "github.com/jinzhu/gorm"
   packages = ["."]
-  revision = "c1b9cf186e4bcd8e5d566ef43f2ae2dfe22dc34e"
+  revision = "6ed508ec6a4ecb3531899a69cbc746ccf65a4166"
+  version = "v1.9.1"
 
 [[projects]]
+  branch = "master"
   name = "github.com/jinzhu/inflection"
   packages = ["."]
-  revision = "74387dc39a75e970e7a3ae6a3386b5bd2e5c5cff"
+  revision = "04140366298a54a039076d798123ffa108fff46c"
 
 [[projects]]
   name = "github.com/jstemmer/go-junit-report"
-  packages = [
-    ".",
-    "formatter",
-    "parser"
-  ]
+  packages = [".","formatter","parser"]
   revision = "master"
 
 [[projects]]
   name = "github.com/jteeuwen/go-bindata"
-  packages = [
-    ".",
-    "go-bindata"
-  ]
+  packages = [".","go-bindata"]
   revision = "bbd0c6e271208dce66d8fda4bc536453cd27fc4a"
   version = "v3.0.7"
 
 [[projects]]
+  branch = "master"
   name = "github.com/lib/pq"
-  packages = [
-    ".",
-    "oid"
-  ]
-  revision = "4a82388ebc5138c8289fe9bc602cb0b3e32cd617"
+  packages = [".","oid"]
+  revision = "d34b9ff171c21ad295489235aec8b6626023cd04"
 
 [[projects]]
   name = "github.com/magiconair/properties"
@@ -198,31 +143,28 @@
   version = "v1.7.6"
 
 [[projects]]
+  branch = "master"
   name = "github.com/manveru/faker"
   packages = ["."]
-  revision = "717f7cf83fb78669bfab612749c2e8ff63d5be11"
+  revision = "9fbc68a78c4dbc7914e1a23f88f126bea4383b97"
 
 [[projects]]
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
-  revision = "fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a"
+  revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
+  version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  revision = "5a0325d7fafaac12dda6e7fb8bd222ec1b69875e"
-
-[[projects]]
-  name = "github.com/pelletier/go-buffruneio"
-  packages = ["."]
-  revision = "c37440a7cf42ac63b919c752ca73a85067e05992"
-  version = "v0.2.0"
+  revision = "00c29f56e2386353d58c599509e8dc3801b0d716"
 
 [[projects]]
   name = "github.com/pelletier/go-toml"
   packages = ["."]
-  revision = "13d49d4606eb801b8f01ae542b4afc4c6ee3d84a"
-  version = "v0.5.0"
+  revision = "acdc4509485b587f5e675510c4f2c63e90ff68a8"
+  version = "v1.1.0"
 
 [[projects]]
   name = "github.com/pkg/errors"
@@ -239,51 +181,50 @@
 [[projects]]
   name = "github.com/prometheus/client_golang"
   packages = ["prometheus"]
-  revision = "e51041b3fa41cece0dca035740ba6411905be473"
+  revision = "c5b7fccd204277076155f10851dad72b76a49317"
+  version = "v0.8.0"
 
 [[projects]]
+  branch = "master"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
-  revision = "fa8ad6fec33561be4280a8f0514318c79d7f6cb6"
+  revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
 
 [[projects]]
+  branch = "master"
   name = "github.com/prometheus/common"
-  packages = [
-    "expfmt",
-    "internal/bitbucket.org/ww/goautoneg",
-    "model"
-  ]
-  revision = "a6ab08426bb262e2d190097751f5cfd1cfdfd17d"
+  packages = ["expfmt","internal/bitbucket.org/ww/goautoneg","model"]
+  revision = "d811d2e9bf898806ecfb6ef6296774b13ffc314c"
 
 [[projects]]
+  branch = "master"
   name = "github.com/prometheus/procfs"
-  packages = ["."]
-  revision = "454a56f35412459b5e684fd5ec0f9211b94f002a"
+  packages = [".","internal/util","nfs","xfs"]
+  revision = "8b1c2da0d56deffdbb9e48d4414b4e674bd8083e"
 
 [[projects]]
   name = "github.com/satori/go.uuid"
   packages = ["."]
-  revision = "879c5887cd475cd7864858769793b2ceb0d44feb"
-  version = "v1.1.0"
+  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
+  version = "v1.2.0"
 
 [[projects]]
   name = "github.com/sirupsen/logrus"
   packages = ["."]
-  revision = "c078b1e43f58d563c74cebe63c85789e76ddb627"
-  version = "v0.11.2"
+  revision = "ba1b36c82c5e05c4f912a88eab0dcd91a171688f"
+  version = "v0.11.5"
 
 [[projects]]
   name = "github.com/spf13/afero"
-  packages = [
-    ".",
-    "mem"
-  ]
-  revision = "2f30b2a92c0e5700bcfe4715891adb1f2a7a406d"
+  packages = [".","mem"]
+  revision = "63644898a8da0bc22138abf860edaf5277b6102e"
+  version = "v1.1.0"
 
 [[projects]]
   name = "github.com/spf13/cast"
   packages = ["."]
-  revision = "24b6558033ffe202bf42f0f3b870dcc798dd2ba8"
+  revision = "8965335b8c7107321228e3e3702cab9832751bac"
+  version = "v1.2.0"
 
 [[projects]]
   name = "github.com/spf13/cobra"
@@ -291,27 +232,26 @@
   revision = "9495bc009a56819bdb0ddbc1a373e29c140bc674"
 
 [[projects]]
+  branch = "master"
   name = "github.com/spf13/jwalterweatherman"
   packages = ["."]
-  revision = "33c24e77fb80341fe7130ee7c594256ff08ccc46"
+  revision = "7c0cea34c8ece3fbeb2b27ab9b59511d360fb394"
 
 [[projects]]
   name = "github.com/spf13/pflag"
   packages = ["."]
-  revision = "5ccb023bc27df288a957c5e994cd44fd19619465"
+  revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
+  version = "v1.0.1"
 
 [[projects]]
   name = "github.com/spf13/viper"
   packages = ["."]
-  revision = "651d9d916abc3c3d6a91a12549495caba5edffd2"
+  revision = "b5e8006cbee93ec955a89ab31e0e3ce3204f3736"
+  version = "v1.0.2"
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = [
-    "assert",
-    "require",
-    "suite"
-  ]
+  packages = ["assert","require","suite"]
   revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
   version = "v1.2.1"
 
@@ -322,65 +262,46 @@
   revision = "795b5e3961ea1912fde60af417ad85e86acc0d6a"
 
 [[projects]]
+  branch = "master"
   name = "golang.org/x/crypto"
-  packages = [
-    "cast5",
-    "ed25519",
-    "ed25519/internal/edwards25519",
-    "openpgp",
-    "openpgp/armor",
-    "openpgp/elgamal",
-    "openpgp/errors",
-    "openpgp/packet",
-    "openpgp/s2k"
-  ]
-  revision = "81e90905daefcd6fd217b62423c0908922eadb30"
+  packages = ["cast5","ed25519","ed25519/internal/edwards25519","openpgp","openpgp/armor","openpgp/elgamal","openpgp/errors","openpgp/packet","openpgp/s2k"]
+  revision = "8b1d31080a7692e075c4681cb2458454a1fe0706"
 
 [[projects]]
+  branch = "master"
   name = "golang.org/x/net"
-  packages = [
-    "context",
-    "websocket"
-  ]
-  revision = "b1a2d6e8c8b5fc8f601ead62536f02a8e1b6217d"
+  packages = ["context","websocket"]
+  revision = "640f4622ab692b87c2f3a94265e6f579fe38263d"
 
 [[projects]]
+  branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "478fcf54317e52ab69f40bb4c7a1520288d7f7ea"
+  revision = "78d5f264b493f125018180c204871ecf58a2dce1"
 
 [[projects]]
   name = "golang.org/x/text"
-  packages = [
-    "internal/gen",
-    "internal/triegen",
-    "internal/ucd",
-    "transform",
-    "unicode/cldr",
-    "unicode/norm"
-  ]
-  revision = "47a200a05c8b3fd1b698571caecbb68beb2611ec"
+  packages = ["internal/gen","internal/triegen","internal/ucd","transform","unicode/cldr","unicode/norm"]
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/tools"
   packages = ["go/ast/astutil"]
-  revision = "77106db15f689a60e7d4e085d967ac557b918fb2"
+  revision = "8026fb003c560896db954319ee6d037f22a8d9c7"
 
 [[projects]]
   name = "gopkg.in/square/go-jose.v2"
-  packages = [
-    ".",
-    "cipher",
-    "json"
-  ]
-  revision = "6ee92191fea850cdcab9a18867abf5f521cdbadb"
-  version = "v2.1.4"
+  packages = [".","cipher","json"]
+  revision = "76dd09796242edb5b897103a75df2645c028c960"
+  version = "v2.1.6"
 
 [[projects]]
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "a5b47d31c556af34a302ce5d659e6fea44d90de0"
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
+  version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/cluster/service_test.go
+++ b/cluster/service_test.go
@@ -79,7 +79,9 @@ func TestResolveCluster(t *testing.T) {
 	defer r.Stop()
 	authURL := "http://authservice"
 	resolveToken := token.NewResolve(authURL, configuration.WithRoundTripper(r.Transport))
-	saToken, err := testsupport.NewToken("tenant_service", "../test/private_key.pem")
+	saToken, err := testsupport.NewToken(map[string]interface{}{
+		"sub": "tenant_service",
+	}, "../test/private_key.pem")
 	require.NoError(t, err)
 
 	t.Run("ok", func(t *testing.T) {

--- a/controller/tenant.go
+++ b/controller/tenant.go
@@ -280,7 +280,7 @@ func (c *TenantController) Show(ctx *app.ShowTenantContext) error {
 // InitTenant is a Callback that assumes a new tenant is being created
 func InitTenant(ctx context.Context, masterURL string, service tenant.Service, currentTenant *tenant.Tenant) openshift.Callback {
 	var maxResourceQuotaStatusCheck int32 = 50 // technically a global retry count across all ResourceQuota on all Tenant Namespaces
-	var currentResourceQuotaStatusCheck int32 = 0
+	var currentResourceQuotaStatusCheck int32  // default is 0
 	return func(statusCode int, method string, request, response map[interface{}]interface{}) (string, map[interface{}]interface{}) {
 		log.Info(ctx, map[string]interface{}{
 			"status":      statusCode,

--- a/controller/tenants.go
+++ b/controller/tenants.go
@@ -1,28 +1,49 @@
 package controller
 
 import (
+	"fmt"
+	"reflect"
+
 	"github.com/fabric8-services/fabric8-tenant/app"
 	"github.com/fabric8-services/fabric8-tenant/cluster"
 	"github.com/fabric8-services/fabric8-tenant/jsonapi"
+	"github.com/fabric8-services/fabric8-tenant/openshift"
 	"github.com/fabric8-services/fabric8-tenant/tenant"
 	"github.com/fabric8-services/fabric8-tenant/token"
+	"github.com/fabric8-services/fabric8-tenant/user"
 	"github.com/fabric8-services/fabric8-wit/errors"
+	"github.com/fabric8-services/fabric8-wit/log"
 	"github.com/goadesign/goa"
 )
 
 // TenantsController implements the tenants resource.
 type TenantsController struct {
 	*goa.Controller
-	tenantService  tenant.Service
-	resolveCluster cluster.Resolve
+	tenantService          tenant.Service
+	resolveTenant          tenant.Resolve
+	userService            user.Service
+	openshiftService       openshift.Service
+	resolveCluster         cluster.Resolve
+	defaultOpenshiftConfig openshift.Config
 }
 
 // NewTenantsController creates a tenants controller.
-func NewTenantsController(service *goa.Service, tenantService tenant.Service, resolveCluster cluster.Resolve) *TenantsController {
+func NewTenantsController(service *goa.Service,
+	tenantService tenant.Service,
+	userService user.Service,
+	openshiftService openshift.Service,
+	resolveTenant tenant.Resolve,
+	resolveCluster cluster.Resolve,
+	defaultOpenshiftConfig openshift.Config,
+) *TenantsController {
 	return &TenantsController{
-		Controller:     service.NewController("TenantsController"),
-		tenantService:  tenantService,
-		resolveCluster: resolveCluster,
+		Controller:             service.NewController("TenantsController"),
+		tenantService:          tenantService,
+		resolveTenant:          resolveTenant,
+		userService:            userService,
+		openshiftService:       openshiftService,
+		resolveCluster:         resolveCluster,
+		defaultOpenshiftConfig: defaultOpenshiftConfig,
 	}
 }
 
@@ -35,6 +56,7 @@ func (c *TenantsController) Show(ctx *app.ShowTenantsContext) error {
 	tenantID := ctx.TenantID
 	tenant, err := c.tenantService.GetTenant(tenantID)
 	if err != nil {
+		log.Error(ctx, map[string]interface{}{"tenant_id": tenantID, "error_type": reflect.TypeOf(err)}, "error while looking-up tenant record")
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 
@@ -51,7 +73,6 @@ func (c *TenantsController) Search(ctx *app.SearchTenantsContext) error {
 	if !token.IsSpecificServiceAccount(ctx, "fabric8-jenkins-idler") {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("Wrong token"))
 	}
-
 	tenant, err := c.tenantService.LookupTenantByClusterAndNamespace(ctx.MasterURL, ctx.Namespace)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)
@@ -72,4 +93,58 @@ func (c *TenantsController) Search(ctx *app.SearchTenantsContext) error {
 		},
 	}
 	return ctx.OK(&result)
+}
+
+// Delete runs the `delete` action to deprovision a user
+func (c *TenantsController) Delete(ctx *app.DeleteTenantsContext) error {
+	if !token.IsSpecificServiceAccount(ctx, "fabric8-auth") {
+		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("Wrong token"))
+	}
+	tenantID := ctx.TenantID
+	// fetch the cluster the user belongs to
+	usr, err := c.userService.GetUser(ctx, tenantID)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, err)
+	}
+	if usr.Cluster == nil {
+		log.Error(ctx, nil, "no cluster defined for tenant")
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, fmt.Errorf("unable to provision to undefined cluster")))
+	}
+	// fetch the cluster info
+	clustr, err := c.resolveCluster(ctx, *usr.Cluster)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"err":         err,
+			"cluster_url": *usr.Cluster,
+			"tenant_id":   tenantID,
+		}, "unable to fetch cluster for user")
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, err))
+	}
+	namespaces, err := c.tenantService.GetNamespaces(tenantID)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, err)
+	}
+	openshiftConfig := openshift.NewConfig(c.defaultOpenshiftConfig, usr, clustr.User, clustr.Token, clustr.APIURL)
+	for _, namespace := range namespaces {
+		log.Info(ctx, map[string]interface{}{"tenant_id": tenantID, "namespace": namespace.Name}, "deleting namespace...")
+		// delete the namespace in the cluster
+		err = c.openshiftService.DeleteNamespace(ctx, openshiftConfig, namespace.Name)
+		if err != nil {
+			log.Error(ctx, map[string]interface{}{
+				"err":         err,
+				"cluster_url": *usr.Cluster,
+				"namespace":   namespace.Name,
+				"tenant_id":   tenantID,
+			}, "failed to delete namespace")
+			return jsonapi.JSONErrorResponse(ctx, err)
+		}
+		// then delete the corresponding record in the DB
+	}
+	// finally, delete the tenant record (all NS were already deleted, but that's fine)
+	err = c.tenantService.DeleteAll(tenantID)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, err)
+	}
+	log.Info(ctx, map[string]interface{}{"tenant_id": tenantID}, "tenant deleted")
+	return ctx.NoContent()
 }

--- a/controller/tenants.go
+++ b/controller/tenants.go
@@ -116,7 +116,6 @@ func (c *TenantsController) Delete(ctx *app.DeleteTenantsContext) error {
 			return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, err))
 		}
 
-		// openshiftConfig := openshift.NewConfig(c.defaultOpenshiftConfig, usr, clustr.User, clustr.Token, clustr.APIURL)
 		openshiftConfig := openshift.Config{
 			MasterURL: namespace.MasterURL,
 			Token:     clustr.Token,

--- a/controller/tenants_test.go
+++ b/controller/tenants_test.go
@@ -56,7 +56,6 @@ func (s *TenantsControllerTestSuite) TestShowTenants() {
 	// given
 	svc, ctrl, err := newTestTenantsController(s.DB, "show-tenants")
 	require.NoError(s.T(), err)
-	s.DB.LogMode(true)
 
 	s.T().Run("OK", func(t *testing.T) {
 		// given
@@ -130,8 +129,6 @@ func (s *TenantsControllerTestSuite) TestSearchTenants() {
 }
 
 func (s *TenantsControllerTestSuite) TestDeleteTenants() {
-
-	// s.DB.LogMode(true)
 
 	s.T().Run("Success", func(t *testing.T) {
 

--- a/controller/tenants_test.go
+++ b/controller/tenants_test.go
@@ -142,12 +142,12 @@ func (s *TenantsControllerTestSuite) TestDeleteTenants() {
 				fxt.Tenants[0].ID = id
 				return nil
 			}), testfixture.Namespaces(2, func(fxt *testfixture.TestFixture, idx int) error {
+				fxt.Namespaces[idx].TenantID = fxt.Tenants[0].ID
+				fxt.Namespaces[idx].MasterURL = "https://api.cluster1"
 				if idx == 0 {
-					fxt.Namespaces[idx].TenantID = fxt.Tenants[0].ID
 					fxt.Namespaces[idx].Name = "foo"
 					fxt.Namespaces[idx].Type = "user"
 				} else if idx == 1 {
-					fxt.Namespaces[idx].TenantID = fxt.Tenants[0].ID
 					fxt.Namespaces[idx].Name = "foo-che"
 					fxt.Namespaces[idx].Type = "che"
 				}
@@ -176,12 +176,12 @@ func (s *TenantsControllerTestSuite) TestDeleteTenants() {
 				fxt.Tenants[0].ID = id
 				return nil
 			}), testfixture.Namespaces(2, func(fxt *testfixture.TestFixture, idx int) error {
+				fxt.Namespaces[idx].TenantID = fxt.Tenants[0].ID
+				fxt.Namespaces[idx].MasterURL = "https://api.cluster1"
 				if idx == 0 {
-					fxt.Namespaces[idx].TenantID = fxt.Tenants[0].ID
 					fxt.Namespaces[idx].Name = "bar"
 					fxt.Namespaces[idx].Type = "user"
 				} else if idx == 1 {
-					fxt.Namespaces[idx].TenantID = fxt.Tenants[0].ID
 					fxt.Namespaces[idx].Name = "bar-che"
 					fxt.Namespaces[idx].Type = "che"
 				}
@@ -232,8 +232,9 @@ func (s *TenantsControllerTestSuite) TestDeleteTenants() {
 				fxt.Tenants[0].ID = id
 				return nil
 			}), testfixture.Namespaces(2, func(fxt *testfixture.TestFixture, idx int) error {
+				fxt.Namespaces[idx].TenantID = fxt.Tenants[0].ID
+				fxt.Namespaces[idx].MasterURL = "https://api.cluster1"
 				if idx == 0 {
-					fxt.Namespaces[idx].TenantID = fxt.Tenants[0].ID
 					fxt.Namespaces[idx].Name = "baz"
 					fxt.Namespaces[idx].Type = "user"
 				} else if idx == 1 {

--- a/controller/tenants_test.go
+++ b/controller/tenants_test.go
@@ -4,32 +4,39 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/fabric8-services/fabric8-tenant/app/test"
 	"github.com/fabric8-services/fabric8-tenant/cluster"
+	"github.com/fabric8-services/fabric8-tenant/configuration"
 	"github.com/fabric8-services/fabric8-tenant/controller"
+	"github.com/fabric8-services/fabric8-tenant/openshift"
 	"github.com/fabric8-services/fabric8-tenant/tenant"
+	testsupport "github.com/fabric8-services/fabric8-tenant/test"
 	"github.com/fabric8-services/fabric8-tenant/test/gormsupport"
+	"github.com/fabric8-services/fabric8-tenant/test/recorder"
 	"github.com/fabric8-services/fabric8-tenant/test/testfixture"
+	"github.com/fabric8-services/fabric8-tenant/token"
+	"github.com/fabric8-services/fabric8-tenant/user"
 	"github.com/fabric8-services/fabric8-wit/errors"
 	"github.com/fabric8-services/fabric8-wit/resource"
 	"github.com/goadesign/goa"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
+	"github.com/jinzhu/gorm"
+	errs "github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
-type TenantControllerTestSuite struct {
+type TenantsControllerTestSuite struct {
 	gormsupport.DBTestSuite
 }
 
-func TestTenantController(t *testing.T) {
+func TestTenantsController(t *testing.T) {
 	resource.Require(t, resource.Database)
-	suite.Run(t, &TenantControllerTestSuite{DBTestSuite: gormsupport.NewDBTestSuite("../config.yaml")})
+	suite.Run(t, &TenantsControllerTestSuite{DBTestSuite: gormsupport.NewDBTestSuite("../config.yaml")})
 }
 
 var resolveCluster = func(ctx context.Context, target string) (*cluster.Cluster, error) {
@@ -44,54 +51,58 @@ var resolveCluster = func(ctx context.Context, target string) (*cluster.Cluster,
 	}, nil
 }
 
-func (s *TenantControllerTestSuite) TestShowTenants() {
+func (s *TenantsControllerTestSuite) TestShowTenants() {
+
+	// given
+	svc, ctrl, err := newTestTenantsController(s.DB, "show-tenants")
+	require.NoError(s.T(), err)
+	s.DB.LogMode(true)
 
 	s.T().Run("OK", func(t *testing.T) {
 		// given
-		tenantID := uuid.NewV4()
-		svc := goa.New("Tenants-service")
-		ctrl := controller.NewTenantsController(svc, mockTenantService{ID: tenantID}, resolveCluster)
+		fxt := testfixture.NewTestFixture(t, s.DB, testfixture.Tenants(1), testfixture.Namespaces(1))
 		// when
-		_, tenant := test.ShowTenantsOK(t, createValidSAContext(), svc, ctrl, tenantID)
+		_, tenant := test.ShowTenantsOK(t, createValidSAContext("fabric8-jenkins-idler"), svc, ctrl, fxt.Tenants[0].ID)
 		// then
-		assert.Equal(t, tenantID, *tenant.Data.ID)
+		assert.Equal(t, fxt.Tenants[0].ID, *tenant.Data.ID)
 		assert.Equal(t, 1, len(tenant.Data.Attributes.Namespaces))
 	})
 
 	s.T().Run("Failures", func(t *testing.T) {
 
-		// given
-		tenantID := uuid.NewV4()
-		svc := goa.New("Tenants-service")
-		ctrl := controller.NewTenantsController(svc, mockTenantService{ID: tenantID}, resolveCluster)
-
 		t.Run("Unauhorized - no token", func(t *testing.T) {
 			// when/then
-			test.ShowTenantsUnauthorized(t, context.Background(), svc, ctrl, tenantID)
+			test.ShowTenantsUnauthorized(t, context.Background(), svc, ctrl, uuid.NewV4())
 		})
 
 		t.Run("Unauhorized - no SA token", func(t *testing.T) {
 			// when/then
-			test.ShowTenantsUnauthorized(t, createInvalidSAContext(), svc, ctrl, tenantID)
+			test.ShowTenantsUnauthorized(t, createInvalidSAContext(), svc, ctrl, uuid.NewV4())
+		})
+
+		t.Run("Unauhorized - wrong SA token", func(t *testing.T) {
+			// when/then
+			test.ShowTenantsUnauthorized(t, createValidSAContext("other service account"), svc, ctrl, uuid.NewV4())
 		})
 
 		t.Run("Not found", func(t *testing.T) {
 			// when/then
-			test.ShowTenantsNotFound(t, createValidSAContext(), svc, ctrl, uuid.NewV4())
+			test.ShowTenantsNotFound(t, createValidSAContext("fabric8-jenkins-idler"), svc, ctrl, uuid.NewV4())
 		})
 	})
 }
 
-func (s *TenantControllerTestSuite) TestSearchTenants() {
+func (s *TenantsControllerTestSuite) TestSearchTenants() {
+
 	// given
-	svc := goa.New("Tenants-service")
+	svc, ctrl, err := newTestTenantsController(s.DB, "search-tenants")
+	require.NoError(s.T(), err)
 
 	s.T().Run("OK", func(t *testing.T) {
 		// given
-		ctrl := controller.NewTenantsController(svc, tenant.NewDBService(s.DB), resolveCluster)
 		fxt := testfixture.NewTestFixture(t, s.DB, testfixture.Tenants(1), testfixture.Namespaces(1))
 		// when
-		_, tenant := test.SearchTenantsOK(t, createValidSAContext(), svc, ctrl, fxt.Namespaces[0].MasterURL, fxt.Namespaces[0].Name)
+		_, tenant := test.SearchTenantsOK(t, createValidSAContext("fabric8-jenkins-idler"), svc, ctrl, fxt.Namespaces[0].MasterURL, fxt.Namespaces[0].Name)
 		// then
 		require.Len(t, tenant.Data, 1)
 		assert.Equal(t, fxt.Tenants[0].ID, *tenant.Data[0].ID)
@@ -99,26 +110,163 @@ func (s *TenantControllerTestSuite) TestSearchTenants() {
 	})
 
 	s.T().Run("Failures", func(t *testing.T) {
-		ctrl := controller.NewTenantsController(svc, mockTenantService{}, resolveCluster)
 
 		t.Run("Unauhorized - no token", func(t *testing.T) {
 			test.SearchTenantsUnauthorized(t, context.Background(), svc, ctrl, "foo", "bar")
 		})
+
 		t.Run("Unauhorized - no SA token", func(t *testing.T) {
 			test.SearchTenantsUnauthorized(t, createInvalidSAContext(), svc, ctrl, "foo", "bar")
 		})
-		t.Run("Not found", func(t *testing.T) {
-			test.SearchTenantsNotFound(t, createValidSAContext(), svc, ctrl, "foo", "bar")
+
+		t.Run("Unauhorized - wrong SA token", func(t *testing.T) {
+			test.SearchTenantsUnauthorized(t, createValidSAContext("other service account"), svc, ctrl, "foo", "bar")
 		})
-		t.Run("Internal Server Error", func(t *testing.T) {
-			test.SearchTenantsInternalServerError(t, createValidSAContext(), svc, ctrl, "", "")
+
+		t.Run("Not found", func(t *testing.T) {
+			test.SearchTenantsNotFound(t, createValidSAContext("fabric8-jenkins-idler"), svc, ctrl, "foo", "bar")
 		})
 	})
 }
 
-func createValidSAContext() context.Context {
+func (s *TenantsControllerTestSuite) TestDeleteTenants() {
+
+	// s.DB.LogMode(true)
+
+	s.T().Run("Success", func(t *testing.T) {
+
+		t.Run("all ok", func(t *testing.T) {
+			// given
+			fxt := testfixture.NewTestFixture(t, s.DB, testfixture.Tenants(1, func(fxt *testfixture.TestFixture, idx int) error {
+				id, err := uuid.FromString("8c97b9fc-2a3f-4bef-8579-75e676ab1348") // force the ID to match the go-vcr cassette in the `delete-tenants.yaml` file
+				if err != nil {
+					return err
+				}
+				fxt.Tenants[0].ID = id
+				return nil
+			}), testfixture.Namespaces(2, func(fxt *testfixture.TestFixture, idx int) error {
+				if idx == 0 {
+					fxt.Namespaces[idx].TenantID = fxt.Tenants[0].ID
+					fxt.Namespaces[idx].Name = "foo"
+					fxt.Namespaces[idx].Type = "user"
+				} else if idx == 1 {
+					fxt.Namespaces[idx].TenantID = fxt.Tenants[0].ID
+					fxt.Namespaces[idx].Name = "foo-che"
+					fxt.Namespaces[idx].Type = "che"
+				}
+				return nil
+			}))
+			svc, ctrl, err := newTestTenantsController(s.DB, "delete-tenants-204")
+			require.NoError(t, err)
+			// when
+			test.DeleteTenantsNoContent(t, createValidSAContext("fabric8-auth"), svc, ctrl, fxt.Tenants[0].ID)
+			// then
+			_, err = tenant.NewDBService(s.DB).GetTenant(fxt.Tenants[0].ID)
+			require.IsType(t, errors.NotFoundError{}, err)
+			namespaces, err := tenant.NewDBService(s.DB).GetNamespaces(fxt.Tenants[0].ID)
+			require.NoError(t, err)
+			assert.Empty(t, namespaces)
+		})
+
+		t.Run("ok even if namespace missing", func(t *testing.T) {
+			// if the namespace record exist in the DB, but the `delete namespace` call on the cluster endpoint fails with a 404
+			// given
+			fxt := testfixture.NewTestFixture(t, s.DB, testfixture.Tenants(1, func(fxt *testfixture.TestFixture, idx int) error {
+				id, err := uuid.FromString("0257147d-0bb8-4624-a054-853e49c97d07") // force the ID to match the go-vcr cassette in the `delete-tenants.yaml` file
+				if err != nil {
+					return err
+				}
+				fxt.Tenants[0].ID = id
+				return nil
+			}), testfixture.Namespaces(2, func(fxt *testfixture.TestFixture, idx int) error {
+				if idx == 0 {
+					fxt.Namespaces[idx].TenantID = fxt.Tenants[0].ID
+					fxt.Namespaces[idx].Name = "bar"
+					fxt.Namespaces[idx].Type = "user"
+				} else if idx == 1 {
+					fxt.Namespaces[idx].TenantID = fxt.Tenants[0].ID
+					fxt.Namespaces[idx].Name = "bar-che"
+					fxt.Namespaces[idx].Type = "che"
+				}
+				return nil
+			}))
+			svc, ctrl, err := newTestTenantsController(s.DB, "delete-tenants-403")
+			require.NoError(t, err)
+			// when
+			test.DeleteTenantsNoContent(t, createValidSAContext("fabric8-auth"), svc, ctrl, fxt.Tenants[0].ID)
+			// then
+			_, err = tenant.NewDBService(s.DB).GetTenant(fxt.Tenants[0].ID)
+			require.IsType(t, errors.NotFoundError{}, err)
+			namespaces, err := tenant.NewDBService(s.DB).GetNamespaces(fxt.Tenants[0].ID)
+			require.NoError(t, err)
+			assert.Empty(t, namespaces)
+		})
+
+	})
+
+	s.T().Run("Failures", func(t *testing.T) {
+
+		svc, ctrl, err := newTestTenantsController(s.DB, "delete-tenants-204")
+		require.NoError(t, err)
+
+		t.Run("Unauhorized - no token", func(t *testing.T) {
+			// when/then
+			test.DeleteTenantsUnauthorized(t, context.Background(), svc, ctrl, uuid.NewV4())
+		})
+
+		t.Run("Unauhorized - no SA token", func(t *testing.T) {
+			// when/then
+			test.DeleteTenantsUnauthorized(t, createInvalidSAContext(), svc, ctrl, uuid.NewV4())
+		})
+
+		t.Run("Unauhorized - wrong SA token", func(t *testing.T) {
+			// when/then
+			test.DeleteTenantsUnauthorized(t, createValidSAContext("other service account"), svc, ctrl, uuid.NewV4())
+		})
+
+		t.Run("namespace deletion failed", func(t *testing.T) {
+			// case where the first namespace could not be deleted: the tenant and the namespaces should still be in the DB
+			// given
+			fxt := testfixture.NewTestFixture(t, s.DB, testfixture.Tenants(1, func(fxt *testfixture.TestFixture, idx int) error {
+				id, err := uuid.FromString("5a95c51b-120a-4d03-b529-98bd7d4a5689") // force the ID to match the go-vcr cassette in the `delete-tenants.yaml` file
+				if err != nil {
+					return err
+				}
+				fxt.Tenants[0].ID = id
+				return nil
+			}), testfixture.Namespaces(2, func(fxt *testfixture.TestFixture, idx int) error {
+				if idx == 0 {
+					fxt.Namespaces[idx].TenantID = fxt.Tenants[0].ID
+					fxt.Namespaces[idx].Name = "baz"
+					fxt.Namespaces[idx].Type = "user"
+				} else if idx == 1 {
+					fxt.Namespaces[idx].TenantID = fxt.Tenants[0].ID
+					fxt.Namespaces[idx].Name = "baz-che"
+					fxt.Namespaces[idx].Type = "che"
+				}
+				return nil
+			}))
+			svc, ctrl, err := newTestTenantsController(s.DB, "delete-tenants-500")
+			require.NoError(t, err)
+			// when
+			test.DeleteTenantsInternalServerError(t, createValidSAContext("fabric8-auth"), svc, ctrl, fxt.Tenants[0].ID)
+			// then
+			_, err = tenant.NewDBService(s.DB).GetTenant(fxt.Tenants[0].ID)
+			require.NoError(t, err)
+			namespaces, err := tenant.NewDBService(s.DB).GetNamespaces(fxt.Tenants[0].ID)
+			require.NoError(t, err)
+			require.Len(t, namespaces, 2)
+			// firs namespace could not be deleted, both still exist in the DB (and in the cluster)
+			assert.Equal(t, "baz", namespaces[0].Name)
+			assert.Equal(t, "baz-che", namespaces[1].Name)
+		})
+	})
+
+}
+
+func createValidSAContext(sub string) context.Context {
 	claims := jwt.MapClaims{}
-	claims["service_accountname"] = "fabric8-jenkins-idler"
+	claims["service_accountname"] = sub
 	token := jwt.NewWithClaims(jwt.SigningMethodRS512, claims)
 	return goajwt.WithJWT(context.Background(), token)
 }
@@ -129,66 +277,51 @@ func createInvalidSAContext() context.Context {
 	return goajwt.WithJWT(context.Background(), token)
 }
 
-type mockTenantService struct {
-	ID uuid.UUID
-}
-
-func (s mockTenantService) Exists(tenantID uuid.UUID) bool {
-	return s.ID == tenantID
-}
-
-func (s mockTenantService) GetTenant(tenantID uuid.UUID) (*tenant.Tenant, error) {
-	if s.ID != tenantID {
-		return nil, errors.NewNotFoundError("tenant", tenantID.String())
+func newTestTenantsController(db *gorm.DB, filename string) (*goa.Service, *controller.TenantsController, error) {
+	r, err := recorder.New(fmt.Sprintf("../test/data/controller/%s", filename), recorder.WithJWTMatcher())
+	if err != nil {
+		return nil, nil, errs.Wrapf(err, "unable to initialize tenant controller")
 	}
-	return &tenant.Tenant{
-		CreatedAt: time.Now(),
-		UpdatedAt: time.Now(),
-		ID:        tenantID,
-		Email:     "test@test.org",
-	}, nil
-}
+	defer r.Stop()
 
-func (s mockTenantService) GetNamespaces(tenantID uuid.UUID) ([]*tenant.Namespace, error) {
-	if s.ID != tenantID {
-		return nil, errors.NewNotFoundError("tenant", tenantID.String())
-	}
-	return []*tenant.Namespace{
-		{
-			CreatedAt: time.Now(),
-			UpdatedAt: time.Now(),
-			ID:        uuid.NewV4(),
-			TenantID:  tenantID,
-			Name:      "test-che",
-			Type:      "che",
-			State:     "created",
-			MasterURL: "http://test.org",
-			Version:   "1.0",
+	saToken, err := testsupport.NewToken(
+		map[string]interface{}{
+			"sub": "tenant_service",
 		},
-	}, nil
-}
-
-func (s mockTenantService) SaveTenant(tenant *tenant.Tenant) error {
-	return nil
-}
-
-func (s mockTenantService) CreateTenant(tenant *tenant.Tenant) error {
-	return nil
-}
-
-func (s mockTenantService) SaveNamespace(namespace *tenant.Namespace) error {
-	return nil
-}
-
-func (s mockTenantService) LookupTenantByClusterAndNamespace(masterURL, namespace string) (*tenant.Tenant, error) {
-	// produce InternalServerError
-	if masterURL == "" || namespace == "" {
-		return nil, fmt.Errorf("mock error")
+		"../test/private_key.pem",
+	)
+	if err != nil {
+		fmt.Printf("error occurred: %v", err)
+		return nil, nil, errs.Wrapf(err, "unable to initialize tenant controller")
 	}
-	return nil, errors.NewNotFoundError("tenant", "")
 
-}
-
-func (s mockTenantService) DeleteAll(tenantID uuid.UUID) error {
-	return nil
+	authURL := "http://authservice"
+	resolveToken := token.NewResolve(authURL, configuration.WithRoundTripper(r.Transport))
+	clusterService := cluster.NewService(
+		authURL,
+		saToken.Raw,
+		resolveToken,
+		token.NewGPGDecypter("foo"),
+		configuration.WithRoundTripper(r.Transport),
+	)
+	clusters, err := clusterService.GetClusters(context.Background())
+	if err != nil {
+		return nil, nil, errs.Wrapf(err, "unable to initialize tenant controller")
+	}
+	resolveCluster := cluster.NewResolve(clusters)
+	resolveTenant := func(ctx context.Context, target, userToken string) (user, accessToken string, err error) {
+		// log.Debug(ctx, map[string]interface{}{"user_token": userToken}, "attempting to resolve tenant for user...")
+		return resolveToken(ctx, target, userToken, false, token.PlainText) // no need to use "forcePull=true" to validate the user's token on the target.
+	}
+	tenantService := tenant.NewDBService(db)
+	userService := user.NewService(
+		authURL,
+		saToken.Raw,
+		configuration.WithRoundTripper(r.Transport),
+	)
+	openshiftService := openshift.NewService(configuration.WithRoundTripper(r.Transport))
+	defaultOpenshiftConfig := openshift.Config{}
+	svc := goa.New("Tenants-service")
+	ctrl := controller.NewTenantsController(svc, tenantService, userService, openshiftService, resolveTenant, resolveCluster, defaultOpenshiftConfig)
+	return svc, ctrl, nil
 }

--- a/design/tenant.go
+++ b/design/tenant.go
@@ -172,6 +172,22 @@ var _ = a.Resource("tenants", func() {
 		a.Response(d.Unauthorized, JSONAPIErrors)
 	})
 
+	a.Action("delete", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.GET("/:tenantID"),
+		)
+		a.Params(func() {
+			a.Param("tenantID", d.UUID, "ID of the tenant to delete/deprovision")
+		})
+		a.Description("delete/deprovision a single tenant environment.")
+		a.Response(d.NoContent)
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+	})
+
 	a.Action("search", func() {
 		a.Security("jwt")
 		a.Routing(

--- a/main.go
+++ b/main.go
@@ -144,6 +144,8 @@ func main() {
 		return resolveToken(ctx, target, userToken, false, token.PlainText) // no need to use "forcePull=true" to validate the user's token on the target.
 	}
 
+	openshiftService := openshift.NewService()
+
 	// create user profile client to get the user's cluster
 	userService := user.NewService(config.GetAuthURL(), *saToken)
 
@@ -172,7 +174,7 @@ func main() {
 	tenantCtrl := controller.NewTenantController(service, tenantService, userService, resolveTenant, resolveCluster, osTemplate, templateVars)
 	app.MountTenantController(service, tenantCtrl)
 
-	tenantsCtrl := controller.NewTenantsController(service, tenantService, resolveCluster)
+	tenantsCtrl := controller.NewTenantsController(service, tenantService, userService, openshiftService, resolveTenant, resolveCluster, osTemplate)
 	app.MountTenantsController(service, tenantsCtrl)
 
 	log.Logger().Infoln("Git Commit SHA: ", controller.Commit)

--- a/openshift/clean_tenant.go
+++ b/openshift/clean_tenant.go
@@ -35,15 +35,17 @@ func CleanTenant(ctx context.Context, config Config, username string, templateVa
 			)
 			if err != nil {
 				log.Error(ctx, map[string]interface{}{
-					"output":    output,
-					"namespace": namespace,
-					"error":     err,
+					"output":      output,
+					"cluster_url": opts.MasterURL,
+					"namespace":   namespace,
+					"error":       err,
 				}, "clean failed")
 				return
 			}
 			log.Info(ctx, map[string]interface{}{
-				"output":    output,
-				"namespace": namespace,
+				"output":      output,
+				"cluster_url": opts.MasterURL,
+				"namespace":   namespace,
 			}, "clean ok")
 		}(key, val, masterOpts, remove)
 	}

--- a/openshift/service.go
+++ b/openshift/service.go
@@ -1,0 +1,67 @@
+package openshift
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/fabric8-services/fabric8-tenant/configuration"
+	"github.com/fabric8-services/fabric8-wit/log"
+	"github.com/pkg/errors"
+)
+
+// Service the Openshift service interface
+type Service interface {
+	DeleteNamespace(ctx context.Context, config Config, namespace string) error
+}
+
+// NewService return a new Openshift service implementation
+func NewService(clientOptions ...configuration.HTTPClientOption) Service {
+	return openShiftService{
+		clientOptions: clientOptions,
+	}
+}
+
+// openShiftService the OpenShift service implementation
+type openShiftService struct {
+	clientOptions []configuration.HTTPClientOption
+}
+
+func (s openShiftService) DeleteNamespace(ctx context.Context, config Config, namespace string) error {
+	opts := ApplyOptions{Config: config}
+	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/apis/project.openshift.io/v1/projects/%s", strings.TrimSuffix(opts.MasterURL, "/"), namespace), nil)
+	if err != nil {
+		return errors.Wrapf(err, "unable to delete the namespace from the API endpoint")
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+opts.Token)
+	client := http.DefaultClient
+	for _, applyOption := range s.clientOptions {
+		applyOption(client)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return errors.Wrapf(err, "unable to delete the namespace from the API endpoint")
+	}
+	defer resp.Body.Close()
+
+	buf := new(bytes.Buffer)
+	_, err = buf.ReadFrom(resp.Body)
+	if err != nil {
+		return errors.Wrapf(err, "unable to delete the namespace from the API endpoint")
+	}
+	body := buf.Bytes()
+	// only report error if the operation did not return a 2xx (OK) or 403 (Forbidden)
+	// actually, Openshift checks if the namespace belongs to the user even before checking if it exists...
+	if resp.StatusCode == http.StatusForbidden {
+		// let's log the error, nonetheless
+		log.Warn(ctx, map[string]interface{}{"namespace": namespace, "message": body}, "failed to delete namespace (but it probably does not exist)")
+	}
+	if resp.StatusCode >= 400 && resp.StatusCode != http.StatusForbidden {
+		return errors.Errorf("unable to delete the namespace from the API endpoint: status=%v message=%s", resp.StatusCode, string(body))
+	}
+	log.Info(ctx, map[string]interface{}{"namespace": namespace}, "deleted namespace")
+	return nil
+}

--- a/openshift/service.go
+++ b/openshift/service.go
@@ -55,11 +55,10 @@ func (s openShiftService) DeleteNamespace(ctx context.Context, config Config, na
 	body := buf.Bytes()
 	// only report error if the operation did not return a 2xx (OK) or 403 (Forbidden)
 	// actually, Openshift checks if the namespace belongs to the user even before checking if it exists...
-	if resp.StatusCode == http.StatusForbidden {
+	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound {
 		// let's log the error, nonetheless
 		log.Warn(ctx, map[string]interface{}{"namespace": namespace, "message": body}, "failed to delete namespace (but it probably does not exist)")
-	}
-	if resp.StatusCode >= 400 && resp.StatusCode != http.StatusForbidden {
+	} else if resp.StatusCode >= 400 { // other errors
 		return errors.Errorf("unable to delete the namespace from the API endpoint: status=%v message=%s", resp.StatusCode, string(body))
 	}
 	log.Info(ctx, map[string]interface{}{"namespace": namespace}, "deleted namespace")

--- a/openshift/whoami.go
+++ b/openshift/whoami.go
@@ -15,7 +15,6 @@ import (
 // WhoAmI checks with OSO who owns the current token.
 // returns the username
 func WhoAmI(ctx context.Context, clusterURL string, token string, clientOptions ...configuration.HTTPClientOption) (string, error) {
-
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/apis/user.openshift.io/v1/users/~", strings.TrimSuffix(clusterURL, "/")), nil)
 	if err != nil {
 		return "", errors.Wrapf(err, "unable to retrieve the username from the `whoami` API endpoint")

--- a/openshift/whoami_test.go
+++ b/openshift/whoami_test.go
@@ -17,7 +17,9 @@ func TestWhoAmI(t *testing.T) {
 	r, err := recorder.New("../test/data/openshift/whoami", recorder.WithJWTMatcher())
 	require.NoError(t, err)
 	defer r.Stop()
-	tok, err := testsupport.NewToken("user_foo", "../test/private_key.pem")
+	tok, err := testsupport.NewToken(map[string]interface{}{
+		"sub": "user_foo",
+	}, "../test/private_key.pem")
 	require.NoError(t, err)
 
 	t.Run("ok", func(t *testing.T) {

--- a/tenant/repository.go
+++ b/tenant/repository.go
@@ -42,8 +42,11 @@ func (s DBService) Exists(tenantID uuid.UUID) bool {
 func (s DBService) GetTenant(tenantID uuid.UUID) (*Tenant, error) {
 	var t Tenant
 	err := s.db.Table(t.TableName()).Where("id = ?", tenantID).Find(&t).Error
-	if err != nil {
-		return nil, err
+	if err == gorm.ErrRecordNotFound {
+		// no match
+		return nil, errors.NewNotFoundError("tenant", tenantID.String())
+	} else if err != nil {
+		return nil, errs.Wrapf(err, "unable to lookup tenant by id")
 	}
 	return &t, nil
 }

--- a/test/data/controller/delete-tenants-204.yaml
+++ b/test/data/controller/delete-tenants-204.yaml
@@ -57,25 +57,6 @@ interactions:
       "groups":[]
     }'
 
-# requests to retrieve the user from auth service, given his/her ID
-- request:
-    method: GET
-    url: http://authservice/api/users/8c97b9fc-2a3f-4bef-8579-75e676ab1348
-    headers:
-      sub: ["tenant_service"] # will be compared against the `sub` claim in the incoming request's token
-  response:
-    status: 200 OK
-    code: 200
-    body: '{ 
-      "data": {
-        "attributes": {
-          "username": "user_foo",
-          "email": "user_foo@bar.com",
-          "cluster": "https://api.cluster1/" 
-        }
-      }
-    }'
-
 # requests to delete the projects on the OSO cluster
 - request:
     method: DELETE
@@ -95,41 +76,3 @@ interactions:
     status: 200 OK
     code: 200
     body: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success"}'
-# case where a "user" ns exists, but the "che" ns does not exist
-- request:
-    method: DELETE
-    url: https://api.cluster1/apis/project.openshift.io/v1/projects/bar
-    headers:
-      sub: ["devtools-sre"] # will be compared against the `sub` claim in the incoming request's token
-  response:
-    status: 200 OK
-    code: 200
-    body: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success"}'
-- request:
-    method: DELETE
-    url: https://api.cluster1/apis/project.openshift.io/v1/projects/bar-che
-    headers:
-      sub: ["devtools-sre"] # will be compared against the `sub` claim in the incoming request's token
-  response:
-    status: 404 Not Found
-    code: 404
-    body: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Not Found"}'
-# case where a "user" ns exists, but the "che" ns deletion failed
-- request:
-    method: DELETE
-    url: https://api.cluster1/apis/project.openshift.io/v1/projects/baz
-    headers:
-      sub: ["devtools-sre"] # will be compared against the `sub` claim in the incoming request's token
-  response:
-    status: 200 OK
-    code: 200
-    body: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success"}'
-- request:
-    method: DELETE
-    url: https://api.cluster1/apis/project.openshift.io/v1/projects/baz-che
-    headers:
-      sub: ["devtools-sre"] # will be compared against the `sub` claim in the incoming request's token
-  response:
-    status: 500 Internal Server Error
-    code: 500
-    body: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Internal Server Error"}'

--- a/test/data/controller/delete-tenants-204.yaml
+++ b/test/data/controller/delete-tenants-204.yaml
@@ -1,0 +1,135 @@
+version: 1
+interactions:
+# requests to retrieve the list of clusters configured in `auth` service
+- request:
+    method: GET
+    url: http://authservice/api/clusters/
+    headers:
+      sub: ["tenant_service"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 200 OK
+    code: 200
+    body: '{
+      "data":[
+        {
+          "name": "cluster_name",
+          "api-url": "https://api.cluster1/",
+          "console-url": "http://console.cluster1/",
+          "metrics-url": "http://metrics.cluster1/",
+          "logging-url": "http://logs.cluster1/",
+          "app-dns": "foo"
+        }
+      ]
+    }'
+
+# requests to resolve the user's token on his/her target cluster
+- request:
+    method: GET
+    url: http://authservice/api/token?for=https%3A%2F%2Fapi.cluster1%2F&force_pull=false
+    headers:
+      sub: ["tenant_service"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 200 OK
+    code: 200
+    # response with encrypted token for the "tenant service" account
+    body: '{ 
+      "token_type": "bearer",
+      "username": "devtools-sre",
+      "access_token": "jA0ECQMCWbHrs0GtZQlg0sDQAYMwVoNofrjMocCLv5+FR4GkCPEOiKvK6ifRVsZ6VWLcBVF5k/MFO0Y3EmE8O77xDFRvA9AVPETb7M873tGXMEmqFjgpWvppN81zgmk/enaeJbTBeYhXScyShw7G7kIbgaRy2ufPzVj7f2muM0PHRS334xOVtWZIuaq4lP7EZvW4u0JinSVT0oIHBoCKDFlMlNS1sTygewyI3QOX1quLEEhaDr6/eTG66aTfqMYZQpM4B+m78mi02GLPx3Z24DpjzgshagmGQ8f2kj49QA0LbbFaCUvpqlyStkXNwFm7z+Vuefpp+XYGbD+8MfOKsQxDr7S6ziEdjs+zt/QAr1ZZyoPsC4TaE6kkY1JHIIcrdO5YoX6mbxDMdkLY1ybMN+qMNKtVW4eV9eh34fZKUJ6sjTfdaZ8DjN+rGDKMtZDqwa1h+YYz938jl/bRBEQjK479o7Y6Iu/v4Rwn4YjM4YGjlXs/T/rUO1uye3AWmVNFfi6GtqNpbsKEbkr80WKOOWiSuYeZHbXA7pWMit17U9LtUA=="
+    }'
+
+# requests to verify that the token is still valid, using the `whoami` API on the user's target cluster
+- request:
+    method: GET
+    url: https://api.cluster1/apis/user.openshift.io/v1/users/~
+    headers:
+      sub: ["devtools-sre"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 200 OK
+    code: 200
+    body: '{
+      "kind":"User",
+      "apiVersion":"user.openshift.io/v1",
+      "metadata":{
+        "name":"devtools-sre",
+      },
+      "identities":[],
+      "groups":[]
+    }'
+
+# requests to retrieve the user from auth service, given his/her ID
+- request:
+    method: GET
+    url: http://authservice/api/users/8c97b9fc-2a3f-4bef-8579-75e676ab1348
+    headers:
+      sub: ["tenant_service"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 200 OK
+    code: 200
+    body: '{ 
+      "data": {
+        "attributes": {
+          "username": "user_foo",
+          "email": "user_foo@bar.com",
+          "cluster": "https://api.cluster1/" 
+        }
+      }
+    }'
+
+# requests to delete the projects on the OSO cluster
+- request:
+    method: DELETE
+    url: https://api.cluster1/apis/project.openshift.io/v1/projects/foo
+    headers:
+      sub: ["devtools-sre"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 200 OK
+    code: 200
+    body: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success"}'
+- request:
+    method: DELETE
+    url: https://api.cluster1/apis/project.openshift.io/v1/projects/foo-che
+    headers:
+      sub: ["devtools-sre"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 200 OK
+    code: 200
+    body: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success"}'
+# case where a "user" ns exists, but the "che" ns does not exist
+- request:
+    method: DELETE
+    url: https://api.cluster1/apis/project.openshift.io/v1/projects/bar
+    headers:
+      sub: ["devtools-sre"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 200 OK
+    code: 200
+    body: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success"}'
+- request:
+    method: DELETE
+    url: https://api.cluster1/apis/project.openshift.io/v1/projects/bar-che
+    headers:
+      sub: ["devtools-sre"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 404 Not Found
+    code: 404
+    body: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Not Found"}'
+# case where a "user" ns exists, but the "che" ns deletion failed
+- request:
+    method: DELETE
+    url: https://api.cluster1/apis/project.openshift.io/v1/projects/baz
+    headers:
+      sub: ["devtools-sre"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 200 OK
+    code: 200
+    body: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success"}'
+- request:
+    method: DELETE
+    url: https://api.cluster1/apis/project.openshift.io/v1/projects/baz-che
+    headers:
+      sub: ["devtools-sre"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 500 Internal Server Error
+    code: 500
+    body: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Internal Server Error"}'

--- a/test/data/controller/delete-tenants-403.yaml
+++ b/test/data/controller/delete-tenants-403.yaml
@@ -57,25 +57,6 @@ interactions:
       "groups":[]
     }'
 
-# requests to retrieve the user from auth service, given his/her ID
-- request:
-    method: GET
-    url: http://authservice/api/users/0257147d-0bb8-4624-a054-853e49c97d07
-    headers:
-      sub: ["tenant_service"] # will be compared against the `sub` claim in the incoming request's token
-  response:
-    status: 200 OK
-    code: 200
-    body: '{ 
-      "data": {
-        "attributes": {
-          "username": "user_foo",
-          "email": "user_foo@bar.com",
-          "cluster": "https://api.cluster1/" 
-        }
-      }
-    }'
-
 # case where a "user" ns exists, but the "che" ns does not exist
 - request:
     method: DELETE

--- a/test/data/controller/delete-tenants-403.yaml
+++ b/test/data/controller/delete-tenants-403.yaml
@@ -1,0 +1,97 @@
+version: 1
+interactions:
+# requests to retrieve the list of clusters configured in `auth` service
+- request:
+    method: GET
+    url: http://authservice/api/clusters/
+    headers:
+      sub: ["tenant_service"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 200 OK
+    code: 200
+    body: '{
+      "data":[
+        {
+          "name": "cluster_name",
+          "api-url": "https://api.cluster1/",
+          "console-url": "http://console.cluster1/",
+          "metrics-url": "http://metrics.cluster1/",
+          "logging-url": "http://logs.cluster1/",
+          "app-dns": "foo"
+        }
+      ]
+    }'
+
+# requests to resolve the user's token on his/her target cluster
+- request:
+    method: GET
+    url: http://authservice/api/token?for=https%3A%2F%2Fapi.cluster1%2F&force_pull=false
+    headers:
+      sub: ["tenant_service"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 200 OK
+    code: 200
+    # response with encrypted token for the "tenant service" account
+    body: '{ 
+      "token_type": "bearer",
+      "username": "devtools-sre",
+      "access_token": "jA0ECQMCWbHrs0GtZQlg0sDQAYMwVoNofrjMocCLv5+FR4GkCPEOiKvK6ifRVsZ6VWLcBVF5k/MFO0Y3EmE8O77xDFRvA9AVPETb7M873tGXMEmqFjgpWvppN81zgmk/enaeJbTBeYhXScyShw7G7kIbgaRy2ufPzVj7f2muM0PHRS334xOVtWZIuaq4lP7EZvW4u0JinSVT0oIHBoCKDFlMlNS1sTygewyI3QOX1quLEEhaDr6/eTG66aTfqMYZQpM4B+m78mi02GLPx3Z24DpjzgshagmGQ8f2kj49QA0LbbFaCUvpqlyStkXNwFm7z+Vuefpp+XYGbD+8MfOKsQxDr7S6ziEdjs+zt/QAr1ZZyoPsC4TaE6kkY1JHIIcrdO5YoX6mbxDMdkLY1ybMN+qMNKtVW4eV9eh34fZKUJ6sjTfdaZ8DjN+rGDKMtZDqwa1h+YYz938jl/bRBEQjK479o7Y6Iu/v4Rwn4YjM4YGjlXs/T/rUO1uye3AWmVNFfi6GtqNpbsKEbkr80WKOOWiSuYeZHbXA7pWMit17U9LtUA=="
+    }'
+
+# requests to verify that the token is still valid, using the `whoami` API on the user's target cluster
+- request:
+    method: GET
+    url: https://api.cluster1/apis/user.openshift.io/v1/users/~
+    headers:
+      sub: ["devtools-sre"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 200 OK
+    code: 200
+    body: '{
+      "kind":"User",
+      "apiVersion":"user.openshift.io/v1",
+      "metadata":{
+        "name":"devtools-sre",
+      },
+      "identities":[],
+      "groups":[]
+    }'
+
+# requests to retrieve the user from auth service, given his/her ID
+- request:
+    method: GET
+    url: http://authservice/api/users/0257147d-0bb8-4624-a054-853e49c97d07
+    headers:
+      sub: ["tenant_service"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 200 OK
+    code: 200
+    body: '{ 
+      "data": {
+        "attributes": {
+          "username": "user_foo",
+          "email": "user_foo@bar.com",
+          "cluster": "https://api.cluster1/" 
+        }
+      }
+    }'
+
+# case where a "user" ns exists, but the "che" ns does not exist
+- request:
+    method: DELETE
+    url: https://api.cluster1/apis/project.openshift.io/v1/projects/bar
+    headers:
+      sub: ["devtools-sre"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 200 OK
+    code: 200
+    body: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success"}'
+- request:
+    method: DELETE
+    url: https://api.cluster1/apis/project.openshift.io/v1/projects/bar-che
+    headers:
+      sub: ["devtools-sre"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 403 Forbidden # OSO responds with this code even if the ns does not exist
+    code: 403
+    body: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Not Found"}'

--- a/test/data/controller/delete-tenants-500.yaml
+++ b/test/data/controller/delete-tenants-500.yaml
@@ -57,25 +57,6 @@ interactions:
       "groups":[]
     }'
 
-# requests to retrieve the user from auth service, given his/her ID
-- request:
-    method: GET
-    url: http://authservice/api/users/8c97b9fc-2a3f-4bef-8579-75e676ab1349
-    headers:
-      sub: ["tenant_service"] # will be compared against the `sub` claim in the incoming request's token
-  response:
-    status: 200 OK
-    code: 200
-    body: '{ 
-      "data": {
-        "attributes": {
-          "username": "user_foo",
-          "email": "user_foo@bar.com",
-          "cluster": "https://api.cluster1/" 
-        }
-      }
-    }'
-
 # case where a "user" ns exists, but the "che" ns deletion failed
 - request:
     method: DELETE

--- a/test/data/controller/delete-tenants-500.yaml
+++ b/test/data/controller/delete-tenants-500.yaml
@@ -1,0 +1,97 @@
+version: 1
+interactions:
+# requests to retrieve the list of clusters configured in `auth` service
+- request:
+    method: GET
+    url: http://authservice/api/clusters/
+    headers:
+      sub: ["tenant_service"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 200 OK
+    code: 200
+    body: '{
+      "data":[
+        {
+          "name": "cluster_name",
+          "api-url": "https://api.cluster1/",
+          "console-url": "http://console.cluster1/",
+          "metrics-url": "http://metrics.cluster1/",
+          "logging-url": "http://logs.cluster1/",
+          "app-dns": "foo"
+        }
+      ]
+    }'
+
+# requests to resolve the user's token on his/her target cluster
+- request:
+    method: GET
+    url: http://authservice/api/token?for=https%3A%2F%2Fapi.cluster1%2F&force_pull=false
+    headers:
+      sub: ["tenant_service"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 200 OK
+    code: 200
+    # response with encrypted token for the "tenant service" account
+    body: '{ 
+      "token_type": "bearer",
+      "username": "devtools-sre",
+      "access_token": "jA0ECQMCWbHrs0GtZQlg0sDQAYMwVoNofrjMocCLv5+FR4GkCPEOiKvK6ifRVsZ6VWLcBVF5k/MFO0Y3EmE8O77xDFRvA9AVPETb7M873tGXMEmqFjgpWvppN81zgmk/enaeJbTBeYhXScyShw7G7kIbgaRy2ufPzVj7f2muM0PHRS334xOVtWZIuaq4lP7EZvW4u0JinSVT0oIHBoCKDFlMlNS1sTygewyI3QOX1quLEEhaDr6/eTG66aTfqMYZQpM4B+m78mi02GLPx3Z24DpjzgshagmGQ8f2kj49QA0LbbFaCUvpqlyStkXNwFm7z+Vuefpp+XYGbD+8MfOKsQxDr7S6ziEdjs+zt/QAr1ZZyoPsC4TaE6kkY1JHIIcrdO5YoX6mbxDMdkLY1ybMN+qMNKtVW4eV9eh34fZKUJ6sjTfdaZ8DjN+rGDKMtZDqwa1h+YYz938jl/bRBEQjK479o7Y6Iu/v4Rwn4YjM4YGjlXs/T/rUO1uye3AWmVNFfi6GtqNpbsKEbkr80WKOOWiSuYeZHbXA7pWMit17U9LtUA=="
+    }'
+
+# requests to verify that the token is still valid, using the `whoami` API on the user's target cluster
+- request:
+    method: GET
+    url: https://api.cluster1/apis/user.openshift.io/v1/users/~
+    headers:
+      sub: ["devtools-sre"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 200 OK
+    code: 200
+    body: '{
+      "kind":"User",
+      "apiVersion":"user.openshift.io/v1",
+      "metadata":{
+        "name":"devtools-sre",
+      },
+      "identities":[],
+      "groups":[]
+    }'
+
+# requests to retrieve the user from auth service, given his/her ID
+- request:
+    method: GET
+    url: http://authservice/api/users/8c97b9fc-2a3f-4bef-8579-75e676ab1349
+    headers:
+      sub: ["tenant_service"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 200 OK
+    code: 200
+    body: '{ 
+      "data": {
+        "attributes": {
+          "username": "user_foo",
+          "email": "user_foo@bar.com",
+          "cluster": "https://api.cluster1/" 
+        }
+      }
+    }'
+
+# case where a "user" ns exists, but the "che" ns deletion failed
+- request:
+    method: DELETE
+    url: https://api.cluster1/apis/project.openshift.io/v1/projects/baz
+    headers:
+      sub: ["devtools-sre"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 500 Internal Server Error
+    code: 500
+    body: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Internal Server Error"}'  
+- request:
+    method: DELETE
+    url: https://api.cluster1/apis/project.openshift.io/v1/projects/baz-che
+    headers:
+      sub: ["devtools-sre"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 200 OK
+    code: 200
+    body: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success"}'

--- a/test/data/controller/search-tenants.yaml
+++ b/test/data/controller/search-tenants.yaml
@@ -1,0 +1,58 @@
+version: 1
+interactions:
+# requests to retrieve the list of clusters configured in `auth` service
+- request:
+    method: GET
+    url: http://authservice/api/clusters/
+    headers:
+      sub: ["tenant_service"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 200 OK
+    code: 200
+    body: '{
+      "data":[
+        {
+          "name": "cluster_name",
+          "api-url": "https://api.cluster1/",
+          "console-url": "http://console.cluster1/",
+          "metrics-url": "http://metrics.cluster1/",
+          "logging-url": "http://logs.cluster1/",
+          "app-dns": "foo"
+        }
+      ]
+    }'
+
+# requests to resolve the user's token on his/her target cluster
+- request:
+    method: GET
+    url: http://authservice/api/token?for=https%3A%2F%2Fapi.cluster1%2F&force_pull=false
+    headers:
+      sub: ["tenant_service"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 200 OK
+    code: 200
+    # response with encrypted token for the "tenant service" account
+    body: '{ 
+      "token_type": "bearer",
+      "username": "devtools-sre",
+      "access_token": "jA0ECQMCWbHrs0GtZQlg0sDQAYMwVoNofrjMocCLv5+FR4GkCPEOiKvK6ifRVsZ6VWLcBVF5k/MFO0Y3EmE8O77xDFRvA9AVPETb7M873tGXMEmqFjgpWvppN81zgmk/enaeJbTBeYhXScyShw7G7kIbgaRy2ufPzVj7f2muM0PHRS334xOVtWZIuaq4lP7EZvW4u0JinSVT0oIHBoCKDFlMlNS1sTygewyI3QOX1quLEEhaDr6/eTG66aTfqMYZQpM4B+m78mi02GLPx3Z24DpjzgshagmGQ8f2kj49QA0LbbFaCUvpqlyStkXNwFm7z+Vuefpp+XYGbD+8MfOKsQxDr7S6ziEdjs+zt/QAr1ZZyoPsC4TaE6kkY1JHIIcrdO5YoX6mbxDMdkLY1ybMN+qMNKtVW4eV9eh34fZKUJ6sjTfdaZ8DjN+rGDKMtZDqwa1h+YYz938jl/bRBEQjK479o7Y6Iu/v4Rwn4YjM4YGjlXs/T/rUO1uye3AWmVNFfi6GtqNpbsKEbkr80WKOOWiSuYeZHbXA7pWMit17U9LtUA=="
+    }'
+
+# requests to verify that the token is still valid, using the `whoami` API on the user's target cluster
+- request:
+    method: GET
+    url: https://api.cluster1/apis/user.openshift.io/v1/users/~
+    headers:
+      sub: ["devtools-sre"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 200 OK
+    code: 200
+    body: '{
+      "kind":"User",
+      "apiVersion":"user.openshift.io/v1",
+      "metadata":{
+        "name":"devtools-sre",
+      },
+      "identities":[],
+      "groups":[]
+    }'

--- a/test/data/controller/show-tenants.yaml
+++ b/test/data/controller/show-tenants.yaml
@@ -1,0 +1,58 @@
+version: 1
+interactions:
+# requests to retrieve the list of clusters configured in `auth` service
+- request:
+    method: GET
+    url: http://authservice/api/clusters/
+    headers:
+      sub: ["tenant_service"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 200 OK
+    code: 200
+    body: '{
+      "data":[
+        {
+          "name": "cluster_name",
+          "api-url": "https://api.cluster1/",
+          "console-url": "http://console.cluster1/",
+          "metrics-url": "http://metrics.cluster1/",
+          "logging-url": "http://logs.cluster1/",
+          "app-dns": "foo"
+        }
+      ]
+    }'
+
+# requests to resolve the user's token on his/her target cluster
+- request:
+    method: GET
+    url: http://authservice/api/token?for=https%3A%2F%2Fapi.cluster1%2F&force_pull=false
+    headers:
+      sub: ["tenant_service"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 200 OK
+    code: 200
+    # response with encrypted token for the "tenant service" account
+    body: '{ 
+      "token_type": "bearer",
+      "username": "devtools-sre",
+      "access_token": "jA0ECQMCWbHrs0GtZQlg0sDQAYMwVoNofrjMocCLv5+FR4GkCPEOiKvK6ifRVsZ6VWLcBVF5k/MFO0Y3EmE8O77xDFRvA9AVPETb7M873tGXMEmqFjgpWvppN81zgmk/enaeJbTBeYhXScyShw7G7kIbgaRy2ufPzVj7f2muM0PHRS334xOVtWZIuaq4lP7EZvW4u0JinSVT0oIHBoCKDFlMlNS1sTygewyI3QOX1quLEEhaDr6/eTG66aTfqMYZQpM4B+m78mi02GLPx3Z24DpjzgshagmGQ8f2kj49QA0LbbFaCUvpqlyStkXNwFm7z+Vuefpp+XYGbD+8MfOKsQxDr7S6ziEdjs+zt/QAr1ZZyoPsC4TaE6kkY1JHIIcrdO5YoX6mbxDMdkLY1ybMN+qMNKtVW4eV9eh34fZKUJ6sjTfdaZ8DjN+rGDKMtZDqwa1h+YYz938jl/bRBEQjK479o7Y6Iu/v4Rwn4YjM4YGjlXs/T/rUO1uye3AWmVNFfi6GtqNpbsKEbkr80WKOOWiSuYeZHbXA7pWMit17U9LtUA=="
+    }'
+
+# requests to verify that the token is still valid, using the `whoami` API on the user's target cluster
+- request:
+    method: GET
+    url: https://api.cluster1/apis/user.openshift.io/v1/users/~
+    headers:
+      sub: ["devtools-sre"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 200 OK
+    code: 200
+    body: '{
+      "kind":"User",
+      "apiVersion":"user.openshift.io/v1",
+      "metadata":{
+        "name":"devtools-sre",
+      },
+      "identities":[],
+      "groups":[]
+    }'

--- a/test/jwt_token.go
+++ b/test/jwt_token.go
@@ -6,10 +6,8 @@ import (
 )
 
 // NewToken creates a new JWT using the given sub claim and signed with the private key in the given filename
-func NewToken(sub string, privatekeyFilename string) (*jwt.Token, error) {
-	claims := jwt.MapClaims{}
-	claims["sub"] = sub
-	token := jwt.NewWithClaims(jwt.SigningMethodRS512, claims)
+func NewToken(claims map[string]interface{}, privatekeyFilename string) (*jwt.Token, error) {
+	token := jwt.NewWithClaims(jwt.SigningMethodRS512, jwt.MapClaims(claims))
 	// use the test private key to sign the token
 	key, err := PrivateKey(privatekeyFilename)
 	if err != nil {
@@ -20,6 +18,6 @@ func NewToken(sub string, privatekeyFilename string) (*jwt.Token, error) {
 		return nil, err
 	}
 	token.Raw = signed
-	log.Debug(nil, map[string]interface{}{"signed_token": signed, "sub": sub}, "generated test token with custom sub")
+	log.Debug(nil, map[string]interface{}{"signed_token": signed, "claims": claims}, "generated test token with custom sub")
 	return token, nil
 }

--- a/test/recorder/recorder.go
+++ b/test/recorder/recorder.go
@@ -72,6 +72,13 @@ func JWTMatcher() cassette.Matcher {
 			return false
 		}
 		claims := token.Claims.(jwt.MapClaims)
+		log.Debug(nil, map[string]interface{}{
+			"httpRequest_method":  httpRequest.Method,
+			"httpRequest_url":     httpRequest.URL,
+			"cassetteRequest_sub": cassetteRequest.Headers["sub"],
+			"request_token_sub":   claims["sub"],
+		}, "comparing `sub` headers")
+
 		if sub, found := cassetteRequest.Headers["sub"]; found {
 			return sub[0] == claims["sub"]
 		}

--- a/token/service_test.go
+++ b/token/service_test.go
@@ -19,7 +19,9 @@ func TestResolveUserToken(t *testing.T) {
 	require.NoError(t, err)
 	defer r.Stop()
 	resolveToken := token.NewResolve("http://authservice", configuration.WithRoundTripper(r.Transport))
-	tok, err := testsupport.NewToken("user_foo", "../test/private_key.pem")
+	tok, err := testsupport.NewToken(map[string]interface{}{
+		"sub": "user_foo",
+	}, "../test/private_key.pem")
 	require.NoError(t, err)
 
 	t.Run("ok", func(t *testing.T) {
@@ -52,7 +54,9 @@ func TestResolveServiceAccountToken(t *testing.T) {
 	require.NoError(t, err)
 	defer r.Stop()
 	resolveToken := token.NewResolve("http://authservice", configuration.WithRoundTripper(r.Transport))
-	tok, err := testsupport.NewToken("tenant_service", "../test/private_key.pem")
+	tok, err := testsupport.NewToken(map[string]interface{}{
+		"sub": "tenant_service",
+	}, "../test/private_key.pem")
 	require.NoError(t, err)
 
 	t.Run("ok", func(t *testing.T) {
@@ -66,7 +70,9 @@ func TestResolveServiceAccountToken(t *testing.T) {
 
 	t.Run("expired token", func(t *testing.T) {
 		// given
-		tok, err := testsupport.NewToken("expired_tenant_service", "../test/private_key.pem")
+		tok, err := testsupport.NewToken(map[string]interface{}{
+			"sub": "expired_tenant_service",
+		}, "../test/private_key.pem")
 		require.NoError(t, err)
 		// when
 		_, _, err = resolveToken(context.Background(), "some_valid_openshift_resource", tok.Raw, true, token.PlainText)

--- a/user/user_service.go
+++ b/user/user_service.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/fabric8-services/fabric8-tenant/auth"
 	authclient "github.com/fabric8-services/fabric8-tenant/auth/client"
+	"github.com/fabric8-services/fabric8-tenant/configuration"
 	goaclient "github.com/goadesign/goa/client"
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
@@ -16,17 +17,22 @@ type Service interface {
 }
 
 // NewService creates a new User service
-func NewService(authURL string, serviceToken string) Service {
-	return &userService{authURL: authURL, serviceToken: serviceToken}
+func NewService(authURL string, serviceToken string, options ...configuration.HTTPClientOption) Service {
+	return &userService{
+		authURL:       authURL,
+		serviceToken:  serviceToken,
+		clientOptions: options,
+	}
 }
 
 type userService struct {
-	authURL      string
-	serviceToken string
+	authURL       string
+	serviceToken  string
+	clientOptions []configuration.HTTPClientOption
 }
 
 func (s *userService) GetUser(ctx context.Context, id uuid.UUID) (*authclient.UserDataAttributes, error) {
-	c, err := auth.NewClient(s.authURL, s.serviceToken)
+	c, err := auth.NewClient(s.authURL, s.serviceToken, s.clientOptions...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Refactored the `tenants` controller to include a new `openshift`
service that provides a method to delete a namespace using the
OSO API. This service can use a different HTTP client transport,
which allows for testing with the `go-vcr` library.

If a namespace deletion fails, the whole deletion stops, except for
`403 Forbidden` responses from OSO which can be returned if the
namespace to delete does not exist. In that case, there's no reason
to halt the tenant deletion.

Fixes openshiftio/openshift.io#3338

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>