### PR TITLE
add capacity flag to namespaces

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -64,8 +64,11 @@
 
 [[projects]]
   name = "github.com/fabric8-services/fabric8-auth"
-  packages = ["design"]
-  revision = "0dd9dae7ea819f950d1a64b8a2241131a29f4028"
+  packages = [
+    "design",
+    "errors"
+  ]
+  revision = "19eb16aaf10758299c4a5360600af983b8470909"
 
 [[projects]]
   name = "github.com/fabric8-services/fabric8-wit"
@@ -382,6 +385,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9a2a5a6ddb109bd13fa7f65f17144be00b9fede1afe83519f7156881d9f5f7c9"
+  inputs-digest = "1b9a2de0300053d7ad432f00112f0589ce9f168227a81f5fc9c33ab6f6e3c816"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -79,7 +79,7 @@ ignored = [
 
 [[constraint]]
   name = "github.com/fabric8-services/fabric8-auth"
-  revision = "0dd9dae7ea819f950d1a64b8a2241131a29f4028"
+  revision = "19eb16aaf10758299c4a5360600af983b8470909"
 
 [[override]]
   name = "github.com/spf13/cobra"

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -16,11 +16,12 @@ import (
 
 // Cluster a cluster
 type Cluster struct {
-	APIURL     string
-	ConsoleURL string
-	MetricsURL string
-	LoggingURL string
-	AppDNS     string
+	APIURL            string
+	ConsoleURL        string
+	MetricsURL        string
+	LoggingURL        string
+	AppDNS            string
+	CapacityExhausted bool
 
 	User  string
 	Token string
@@ -96,13 +97,15 @@ func (s *clusterService) GetClusters(ctx context.Context) ([]*Cluster, error) {
 		}
 
 		cls = append(cls, &Cluster{
-			APIURL:     cluster.APIURL,
-			AppDNS:     cluster.AppDNS,
-			ConsoleURL: cluster.ConsoleURL,
-			MetricsURL: cluster.MetricsURL,
-			LoggingURL: cluster.LoggingURL,
-			User:       clusterUser,
-			Token:      clusterToken,
+			APIURL:            cluster.APIURL,
+			AppDNS:            cluster.AppDNS,
+			ConsoleURL:        cluster.ConsoleURL,
+			MetricsURL:        cluster.MetricsURL,
+			LoggingURL:        cluster.LoggingURL,
+			CapacityExhausted: cluster.CapacityExhausted,
+
+			User:  clusterUser,
+			Token: clusterToken,
 		})
 	}
 	return cls, nil

--- a/cluster/service_test.go
+++ b/cluster/service_test.go
@@ -103,6 +103,6 @@ func TestResolveCluster(t *testing.T) {
 		assert.Equal(t, "http://logging.cluster1/", clusters[0].LoggingURL)
 		assert.Equal(t, saToken.Raw, clusters[0].Token) // see decode_test.go for decoded value of data in yaml file
 		assert.Equal(t, "tenant_service", clusters[0].User)
-
+		assert.Equal(t, false, clusters[0].CapacityExhausted)
 	})
 }

--- a/controller/tenant.go
+++ b/controller/tenant.go
@@ -440,6 +440,7 @@ func convertTenant(ctx context.Context, tenant *tenant.Tenant, namespaces []*ten
 				Type:              &tenantType,
 				Version:           &ns.Version,
 				State:             &ns.State,
+				ClusterCapacityExhausted: &c.CapacityExhausted,
 			})
 	}
 	return &result

--- a/controller/tenant_test.go
+++ b/controller/tenant_test.go
@@ -1,0 +1,114 @@
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/fabric8-services/fabric8-tenant/app"
+	"github.com/fabric8-services/fabric8-tenant/cluster"
+	"github.com/fabric8-services/fabric8-tenant/tenant"
+
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/require"
+)
+
+var resolveCluster = func(ctx context.Context, target string) (*cluster.Cluster, error) {
+	return &cluster.Cluster{
+		AppDNS:            "apps.example.com",
+		ConsoleURL:        "https://console.example.com/console",
+		MetricsURL:        "https://metrics.example.com",
+		LoggingURL:        "https://console.example.com/console", // not a typo; logging and console are on the same host
+		CapacityExhausted: true,
+	}, nil
+}
+
+func namespaces(ns1, ns2 time.Time) []*tenant.Namespace {
+	return []*tenant.Namespace{
+		{
+			CreatedAt: ns1,
+			UpdatedAt: ns1,
+			MasterURL: "http://test1.org",
+			Name:      "test-che",
+			Type:      tenant.TypeChe,
+			Version:   "1.0",
+			State:     "created",
+		},
+		{
+			CreatedAt: ns2,
+			UpdatedAt: ns2,
+			MasterURL: "http://test2.org",
+			Name:      "test-jenkins",
+			Type:      tenant.TypeJenkins,
+			Version:   "1.0",
+			State:     "created",
+		},
+	}
+}
+
+func Test_convertTenant(t *testing.T) {
+	ctx := context.Background()
+
+	tenantCreated := time.Now()
+	tenantID := uuid.NewV4()
+	tenant := &tenant.Tenant{
+		ID:        tenantID,
+		Email:     "q@x.com",
+		Profile:   "Q X",
+		CreatedAt: tenantCreated,
+	}
+
+	ns1Time, ns2Time := time.Now(), time.Now()
+	namespaces := namespaces(ns1Time, ns2Time)
+	want := &app.Tenant{
+		ID:   &tenantID,
+		Type: "tenants",
+		Attributes: &app.TenantAttributes{
+			CreatedAt: &tenantCreated,
+			Email:     strToPtr("q@x.com"),
+			Profile:   strToPtr("Q X"),
+			Namespaces: []*app.NamespaceAttributes{
+				{
+					CreatedAt:         &ns1Time,
+					UpdatedAt:         &ns1Time,
+					ClusterURL:        strToPtr("http://test1.org"),
+					ClusterAppDomain:  strToPtr("apps.example.com"),
+					ClusterConsoleURL: strToPtr("https://console.example.com/console"),
+					ClusterMetricsURL: strToPtr("https://metrics.example.com"),
+					ClusterLoggingURL: strToPtr("https://console.example.com/console"),
+					Name:              strToPtr("test-che"),
+					Type:              strToPtr("che"),
+					Version:           strToPtr("1.0"),
+					State:             strToPtr("created"),
+					ClusterCapacityExhausted: boolToPtr(true),
+				},
+				{
+					CreatedAt:         &ns2Time,
+					UpdatedAt:         &ns2Time,
+					ClusterURL:        strToPtr("http://test2.org"),
+					ClusterAppDomain:  strToPtr("apps.example.com"),
+					ClusterConsoleURL: strToPtr("https://console.example.com/console"),
+					ClusterMetricsURL: strToPtr("https://metrics.example.com"),
+					ClusterLoggingURL: strToPtr("https://console.example.com/console"),
+					Name:              strToPtr("test-jenkins"),
+					Type:              strToPtr("jenkins"),
+					Version:           strToPtr("1.0"),
+					State:             strToPtr("created"),
+					ClusterCapacityExhausted: boolToPtr(true),
+				},
+			},
+		},
+	}
+
+	got := convertTenant(ctx, tenant, namespaces, resolveCluster)
+
+	require.Equal(t, want, got)
+}
+
+func strToPtr(s string) *string {
+	return &s
+}
+
+func boolToPtr(b bool) *bool {
+	return &b
+}

--- a/design/tenant.go
+++ b/design/tenant.go
@@ -58,6 +58,8 @@ var namespaceAttributes = a.Type("NamespaceAttributes", func() {
 	})
 	a.Attribute("cluster-app-domain", d.String, "The cluster app domain", func() {
 	})
+	a.Attribute("cluster-capacity-exhausted", d.Boolean, "Whether cluster hosting this namespace exhausted it's capacity", func() {
+	})
 	a.Attribute("type", d.String, "The tenant namespaces", func() {
 		a.Enum("user", "che", "jenkins", "stage", "test", "run")
 	})

--- a/test/data/cluster/resolve_cluster.yaml
+++ b/test/data/cluster/resolve_cluster.yaml
@@ -17,7 +17,8 @@ interactions:
           "console-url": "http://console.cluster1/console/",
           "metrics-url": "http://metrics.cluster1/",
           "logging-url": "http://logging.cluster1/",
-          "app-dns": "foo"
+          "app-dns": "foo",
+          "capacity-exhausted": false
         }
       ]
     }'


### PR DESCRIPTION
Now when calling `/api/tenant` and `/api/tenants`, now the namespaces
information that is returned by tenant service will also include an
attribute `cluster-capacity-exhausted` which is a boolean which
indicates if the cluster this namespace is hosted on has exhausted it's
resources or is still capable of running more workloads.

Taking stab at https://github.com/openshiftio/openshift.io/issues/3320