### PR TITLE
Move to Quay.io

### DIFF
--- a/Dockerfile.deploy.rhel
+++ b/Dockerfile.deploy.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/pcp:latest
+FROM quay.io/openshiftio/rhel-base-pcp:latest
 LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Devtools <devtools@redhat.com>"
 

--- a/OpenShiftTemplate.yml
+++ b/OpenShiftTemplate.yml
@@ -161,6 +161,6 @@ objects:
       deploymentconfig: f8tenant
 parameters:
 - name: IMAGE
-  value: registry.devshift.net/fabric8-services/fabric8-tenant
+  value: quay.io/openshiftio/rhel-fabric8-services-fabric8-tenant
 - name: IMAGE_TAG
   value: latest

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -9,12 +9,8 @@ set -e
 # Source environment variables of the jenkins slave
 # that might interest this worker.
 function load_jenkins_vars() {
-  if [ -e "jenkins-env" ]; then
-    cat jenkins-env \
-      | grep -E "(DEVSHIFT_TAG_LEN|DEVSHIFT_USERNAME|DEVSHIFT_PASSWORD|JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId)=" \
-      | sed 's/^/export /g' \
-      > ~/.jenkins-env
-    source ~/.jenkins-env
+  if [ -e "jenkins-env.json" ]; then
+    eval "$(./env-toolkit load -f jenkins-env.json DEVSHIFT_TAG_LEN QUAY_USERNAME QUAY_PASSWORD JENKINS_URL GIT_BRANCH GIT_COMMIT BUILD_NUMBER ghprbSourceBranch ghprbActualCommit BUILD_URL ghprbPullId)"
   fi
 }
 
@@ -109,10 +105,10 @@ function tag_push() {
 
 function deploy() {
   TAG=$(echo $GIT_COMMIT | cut -c1-${DEVSHIFT_TAG_LEN})
-  REGISTRY="push.registry.devshift.net"
+  REGISTRY="quay.io"
 
-  if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
-    docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} ${REGISTRY}
+  if [ -n "${QUAY_USERNAME}" -a -n "${QUAY_PASSWORD}" ]; then
+    docker login -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD} ${REGISTRY}
   else
     echo "Could not login, missing credentials for the registry"
   fi
@@ -121,11 +117,11 @@ function deploy() {
   make docker-image-deploy
 
   if [ "$TARGET" = "rhel" ]; then
-    tag_push ${REGISTRY}/osio-prod/fabric8-services/fabric8-tenant:$TAG
-    tag_push ${REGISTRY}/osio-prod/fabric8-services/fabric8-tenant:latest
+    tag_push ${REGISTRY}/openshiftio/rhel-fabric8-services-fabric8-tenant:$TAG
+    tag_push ${REGISTRY}/openshiftio/rhel-fabric8-services-fabric8-tenant:latest
   else
-    tag_push ${REGISTRY}/fabric8-services/fabric8-tenant:$TAG
-    tag_push ${REGISTRY}/fabric8-services/fabric8-tenant:latest
+    tag_push ${REGISTRY}/openshiftio/fabric8-services-fabric8-tenant:$TAG
+    tag_push ${REGISTRY}/openshiftio/fabric8-services-fabric8-tenant:latest
   fi
 
   echo 'CICO: Image pushed, ready to update deployed app'


### PR DESCRIPTION
This PR is part of the effort to move to Quay.

This is the list of changes in this PR:

- Pushes to Quay instead of the Devshift registry
- Uses an image hosted in Quay to build the RHEL based container image
- Uses the new env-toolkit to load variables from jenkins-env
- Changes the default path of the image to quay (note that this should not affect production because it is overridden in the saas repo)

A companion PR should have been submitted to the appropriate saas repo to change the staging url from devshift to quay. The PR to the saas repo should be merged before this one.
https://github.com/openshiftio/saas-openshiftio/pull/914