### PR TITLE
fix: detect user ns when has same name as the username is

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,310 +3,580 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:f57ef73de6f603edb0a8e8d72e332ef3d58ecf63b77615f0f5d93b3d12c78064"
   name = "github.com/Unleash/unleash-client-go"
-  packages = [".","context","internal/api","internal/strategies","strategy"]
+  packages = [
+    ".",
+    "context",
+    "internal/api",
+    "internal/strategies",
+    "strategy",
+  ]
+  pruneopts = "UT"
   revision = "be883ea1af714aff427d0668dbd4fc549d4f701c"
 
 [[projects]]
+  digest = "1:2aff5edb9bccd2974090fddb17ca7ab05a3f5c983db567c30c7f0b53404f5783"
   name = "github.com/ajg/form"
   packages = ["."]
+  pruneopts = "UT"
   revision = "cc2954064ec9ea8d93917f0f87456e11d7b881ad"
   version = "v1.5"
 
 [[projects]]
   branch = "master"
+  digest = "1:66dfcb33994918d290a70f58ef42bda92a7268facf17bd937f5748dec853a320"
   name = "github.com/armon/go-metrics"
   packages = ["."]
+  pruneopts = "UT"
   revision = "783273d703149aaeb9897cf58613d5af48861c25"
 
 [[projects]]
   branch = "master"
+  digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
+  pruneopts = "UT"
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "UT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:bb2130e54ac8ea3ff78312ca365ce3b8a23423ed362530551bdceaccfa4d8e77"
   name = "github.com/dgrijalva/jwt-go"
-  packages = [".","request"]
+  packages = [
+    ".",
+    "request",
+  ]
+  pruneopts = "UT"
   revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
   version = "v3.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:376e5a9fdb57657725ff19b4c510c3f5e1f804ab4ab0ff3064d8f4dc01e40fe2"
   name = "github.com/dimfeld/httppath"
   packages = ["."]
+  pruneopts = "UT"
   revision = "ee938bf735983d53694d79138ad9820efff94c92"
 
 [[projects]]
+  digest = "1:8d983343581370768675191a8695f52d663f50a9234c571128f3d146314892cf"
   name = "github.com/dimfeld/httptreemux"
   packages = ["."]
+  pruneopts = "UT"
   revision = "7f532489e7739b3d49df5c602bf63549881fe753"
   version = "v5.0.1"
 
 [[projects]]
+  digest = "1:7e48c90132794b154a515880373083a86b35b2701d2bd502fbe505da7921a049"
   name = "github.com/dnaeon/go-vcr"
-  packages = ["cassette","recorder"]
+  packages = [
+    "cassette",
+    "recorder",
+  ]
+  pruneopts = "UT"
   revision = "fd097d581a47517ee36686adfd3153d6f8eca367"
   source = "https://github.com/xcoulon/go-vcr/"
 
 [[projects]]
+  digest = "1:258f52523a7a6ba109904e0d09865b7f10fa07c9a19c70dd93d109085a6f88e1"
   name = "github.com/fabric8-services/fabric8-auth"
-  packages = ["design","errors"]
+  packages = [
+    "design",
+    "errors",
+  ]
+  pruneopts = "UT"
   revision = "19eb16aaf10758299c4a5360600af983b8470909"
 
 [[projects]]
   branch = "master"
+  digest = "1:055f718d566aba9f32badb8adaa7246940a0bbdbafa2751050988e8afd1c4313"
   name = "github.com/fabric8-services/fabric8-wit"
-  packages = ["configuration","errors","goamiddleware","log","resource","rest"]
+  packages = [
+    "configuration",
+    "errors",
+    "goamiddleware",
+    "log",
+    "resource",
+    "rest",
+  ]
+  pruneopts = "UT"
   revision = "b59d0dc8ae9b2bfea1fb5dc6ff3552c42b735756"
 
 [[projects]]
+  digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
+  pruneopts = "UT"
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
   version = "v1.4.7"
 
 [[projects]]
+  digest = "1:5d894fc1aab279156862831645e0fd24623a6b9010d459c239c1e4392c5752fb"
   name = "github.com/goadesign/goa"
-  packages = [".","client","cors","design","design/apidsl","dslengine","encoding/form","goagen","goagen/codegen","goagen/gen_app","goagen/gen_client","goagen/gen_controller","goagen/gen_main","goagen/gen_schema","goagen/gen_swagger","goagen/meta","goagen/utils","goatest","logging/logrus","middleware","middleware/gzip","middleware/security/jwt","uuid","version"]
+  packages = [
+    ".",
+    "client",
+    "cors",
+    "design",
+    "design/apidsl",
+    "dslengine",
+    "encoding/form",
+    "goagen",
+    "goagen/codegen",
+    "goagen/gen_app",
+    "goagen/gen_client",
+    "goagen/gen_controller",
+    "goagen/gen_main",
+    "goagen/gen_schema",
+    "goagen/gen_swagger",
+    "goagen/meta",
+    "goagen/utils",
+    "goatest",
+    "logging/logrus",
+    "middleware",
+    "middleware/gzip",
+    "middleware/security/jwt",
+    "uuid",
+    "version",
+  ]
+  pruneopts = "UT"
   revision = "5646a430cdeb66983d5ace3384e0a667c185abc7"
   version = "v1.3.0"
 
 [[projects]]
+  digest = "1:15042ad3498153684d09f393bbaec6b216c8eec6d61f63dff711de7d64ed8861"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
+  pruneopts = "UT"
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:2394f5a25132b3868eff44599cc28d44bdd0330806e34c495d754dd052df612b"
   name = "github.com/hashicorp/go-immutable-radix"
   packages = ["."]
+  pruneopts = "UT"
   revision = "7f3cd4390caab3250a57f30efdb2a65dd7649ecf"
 
 [[projects]]
   branch = "master"
+  digest = "1:e0e3eb7886110c57a7c103fbc5fc419b1651d3014655b47b71f26809c2daeb1c"
   name = "github.com/hashicorp/golang-lru"
   packages = ["simplelru"]
+  pruneopts = "UT"
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
   branch = "master"
+  digest = "1:a361611b8c8c75a1091f00027767f7779b29cb37c456a71b8f2604c88057ab40"
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/printer","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/printer",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token",
+  ]
+  pruneopts = "UT"
   revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
 
 [[projects]]
+  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
+  pruneopts = "UT"
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
 
 [[projects]]
+  digest = "1:235ae01f32fb5f12c5f6d2e0e05ab48e651ab31c126e45a4efc4f510810941ac"
   name = "github.com/jinzhu/gorm"
   packages = ["."]
+  pruneopts = "UT"
   revision = "6ed508ec6a4ecb3531899a69cbc746ccf65a4166"
   version = "v1.9.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:fd97437fbb6b7dce04132cf06775bd258cce305c44add58eb55ca86c6c325160"
   name = "github.com/jinzhu/inflection"
   packages = ["."]
+  pruneopts = "UT"
   revision = "04140366298a54a039076d798123ffa108fff46c"
 
 [[projects]]
+  digest = "1:cbf8fd4a701702dd0b2c9382a5b4151646bdb4afbd653b563e54d92566405f8b"
   name = "github.com/jstemmer/go-junit-report"
-  packages = [".","formatter","parser"]
+  packages = [
+    ".",
+    "formatter",
+    "parser",
+  ]
+  pruneopts = "UT"
   revision = "master"
 
 [[projects]]
+  digest = "1:611cdcd3bd9781ebe9ea11d21edbb71528ad75bf3ff76fc41897f20b4c787d98"
   name = "github.com/jteeuwen/go-bindata"
-  packages = [".","go-bindata"]
+  packages = [
+    ".",
+    "go-bindata",
+  ]
+  pruneopts = "UT"
   revision = "bbd0c6e271208dce66d8fda4bc536453cd27fc4a"
   version = "v3.0.7"
 
 [[projects]]
   branch = "master"
+  digest = "1:1e537dfb7b4d543e25efa2c812084dd65736f8010979c1b7e167a5b876563199"
   name = "github.com/lib/pq"
-  packages = [".","oid"]
+  packages = [
+    ".",
+    "oid",
+  ]
+  pruneopts = "UT"
   revision = "d34b9ff171c21ad295489235aec8b6626023cd04"
 
 [[projects]]
+  digest = "1:5149009cc36718234a9ad2896b04b04716808b8d72143b5687c0a15b53132b27"
   name = "github.com/magiconair/properties"
   packages = ["."]
+  pruneopts = "UT"
   revision = "c3beff4c2358b44d0493c7dda585e7db7ff28ae6"
   version = "v1.7.6"
 
 [[projects]]
   branch = "master"
+  digest = "1:393f23e872c9141dbe315c428dc3eac9406f029be7ab0e1cae2374486c07aa54"
   name = "github.com/manveru/faker"
   packages = ["."]
+  pruneopts = "UT"
   revision = "9fbc68a78c4dbc7914e1a23f88f126bea4383b97"
 
 [[projects]]
+  digest = "1:5985ef4caf91ece5d54817c11ea25f182697534f8ae6521eadcd628c142ac4b6"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
+  pruneopts = "UT"
   revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:2514da1e59c0a936d8c1e0fbf5592267a3c5893eb4555ce767bb54d149e9cf6e"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
+  pruneopts = "UT"
   revision = "00c29f56e2386353d58c599509e8dc3801b0d716"
 
 [[projects]]
+  digest = "1:7231124c9669dfb54b82ef8b89f2735cf5d5d2529a23c6ac93a8c4b8bbb28b28"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
+  pruneopts = "UT"
   revision = "acdc4509485b587f5e675510c4f2c63e90ff68a8"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = "UT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:b6221ec0f8903b556e127c449e7106b63e6867170c2d10a7c058623d086f2081"
   name = "github.com/prometheus/client_golang"
   packages = ["prometheus"]
+  pruneopts = "UT"
   revision = "c5b7fccd204277076155f10851dad72b76a49317"
   version = "v0.8.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:32d10bdfa8f09ecf13598324dba86ab891f11db3c538b6a34d1c3b5b99d7c36b"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
+  pruneopts = "UT"
   revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
 
 [[projects]]
   branch = "master"
+  digest = "1:e469cd65badf7694aeb44874518606d93c1d59e7735d3754ad442782437d3cc3"
   name = "github.com/prometheus/common"
-  packages = ["expfmt","internal/bitbucket.org/ww/goautoneg","model"]
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model",
+  ]
+  pruneopts = "UT"
   revision = "d811d2e9bf898806ecfb6ef6296774b13ffc314c"
 
 [[projects]]
   branch = "master"
+  digest = "1:570784e0ddbf67f14087c6d8cfb7b999b9c55e75518a755e88cb202566ea8a17"
   name = "github.com/prometheus/procfs"
-  packages = [".","internal/util","nfs","xfs"]
+  packages = [
+    ".",
+    "internal/util",
+    "nfs",
+    "xfs",
+  ]
+  pruneopts = "UT"
   revision = "8b1c2da0d56deffdbb9e48d4414b4e674bd8083e"
 
 [[projects]]
+  digest = "1:274f67cb6fed9588ea2521ecdac05a6d62a8c51c074c1fccc6a49a40ba80e925"
   name = "github.com/satori/go.uuid"
   packages = ["."]
+  pruneopts = "UT"
   revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:8011d6367a04c40f1a9f50274e5e22b1cd5c05104d87cd8cf21d5a56c0cc3bd8"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
+  pruneopts = "UT"
   revision = "ba1b36c82c5e05c4f912a88eab0dcd91a171688f"
   version = "v0.11.5"
 
 [[projects]]
+  digest = "1:fe0b7f0c9a5e5511001fe085b0a156b29266012cd984a63e4059a30e84bba03a"
   name = "github.com/spf13/afero"
-  packages = [".","mem"]
+  packages = [
+    ".",
+    "mem",
+  ]
+  pruneopts = "UT"
   revision = "63644898a8da0bc22138abf860edaf5277b6102e"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:516e71bed754268937f57d4ecb190e01958452336fa73dbac880894164e91c1f"
   name = "github.com/spf13/cast"
   packages = ["."]
+  pruneopts = "UT"
   revision = "8965335b8c7107321228e3e3702cab9832751bac"
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:466208cd4f78e2a453d92381511c0fa7bba694a3b42e5bed4a59f3ecbe1bb567"
   name = "github.com/spf13/cobra"
   packages = ["."]
+  pruneopts = "UT"
   revision = "9495bc009a56819bdb0ddbc1a373e29c140bc674"
 
 [[projects]]
   branch = "master"
+  digest = "1:080e5f630945ad754f4b920e60b4d3095ba0237ebf88dc462eb28002932e3805"
   name = "github.com/spf13/jwalterweatherman"
   packages = ["."]
+  pruneopts = "UT"
   revision = "7c0cea34c8ece3fbeb2b27ab9b59511d360fb394"
 
 [[projects]]
+  digest = "1:9424f440bba8f7508b69414634aef3b2b3a877e522d8a4624692412805407bb7"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = "UT"
   revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:59e7dceb53b4a1e57eb1eb0bf9951ff0c25912df7660004a789b62b4e8cdca3b"
   name = "github.com/spf13/viper"
   packages = ["."]
+  pruneopts = "UT"
   revision = "b5e8006cbee93ec955a89ab31e0e3ce3204f3736"
   version = "v1.0.2"
 
 [[projects]]
+  digest = "1:c52d48fe752736ae45b72959e1e4fc1a5b60d5b56f8fad42c58414daab5f309d"
   name = "github.com/stretchr/testify"
-  packages = ["assert","require","suite"]
+  packages = [
+    "assert",
+    "require",
+    "suite",
+  ]
+  pruneopts = "UT"
   revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
   version = "v1.2.1"
 
 [[projects]]
+  digest = "1:7bff42fbbef28d0ef60138c92cb3872cacb035133b3cfa39e3ff2c43f1fc332e"
+  name = "github.com/wadey/gocovmerge"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "master"
+
+[[projects]]
   branch = "master"
+  digest = "1:6f7f5a5452e6dc8b0665b0fd2b779c3c6b7e70a121e0661aeb03daef7baae58d"
   name = "github.com/zach-klippenstein/goregen"
   packages = ["."]
+  pruneopts = "UT"
   revision = "795b5e3961ea1912fde60af417ad85e86acc0d6a"
 
 [[projects]]
   branch = "master"
+  digest = "1:0abcbe49b70ffb57cc089bb72434f34cc051d1a35e27827730a5fe9490be8edf"
   name = "golang.org/x/crypto"
-  packages = ["cast5","ed25519","ed25519/internal/edwards25519","openpgp","openpgp/armor","openpgp/elgamal","openpgp/errors","openpgp/packet","openpgp/s2k"]
+  packages = [
+    "cast5",
+    "ed25519",
+    "ed25519/internal/edwards25519",
+    "openpgp",
+    "openpgp/armor",
+    "openpgp/elgamal",
+    "openpgp/errors",
+    "openpgp/packet",
+    "openpgp/s2k",
+  ]
+  pruneopts = "UT"
   revision = "8b1d31080a7692e075c4681cb2458454a1fe0706"
 
 [[projects]]
   branch = "master"
+  digest = "1:d6eb74ab0724315b0197fefd4010de15fbc4da0900a1a6f95c9354c1662036f7"
   name = "golang.org/x/net"
-  packages = ["context","websocket"]
+  packages = [
+    "context",
+    "websocket",
+  ]
+  pruneopts = "UT"
   revision = "640f4622ab692b87c2f3a94265e6f579fe38263d"
 
 [[projects]]
   branch = "master"
+  digest = "1:82076c8f541fde4d040d27f2f2c8215620d8bec3c8c4a8119c3179460396e916"
   name = "golang.org/x/sys"
   packages = ["unix"]
+  pruneopts = "UT"
   revision = "78d5f264b493f125018180c204871ecf58a2dce1"
 
 [[projects]]
+  digest = "1:8029e9743749d4be5bc9f7d42ea1659471767860f0cdc34d37c3111bd308a295"
   name = "golang.org/x/text"
-  packages = ["internal/gen","internal/triegen","internal/ucd","transform","unicode/cldr","unicode/norm"]
+  packages = [
+    "internal/gen",
+    "internal/triegen",
+    "internal/ucd",
+    "transform",
+    "unicode/cldr",
+    "unicode/norm",
+  ]
+  pruneopts = "UT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:238dcb4bf4569d200ffb0fdf0a0042c70b907e133dea0dfc4d377c6f9bf1c010"
   name = "golang.org/x/tools"
-  packages = ["go/ast/astutil"]
+  packages = [
+    "cover",
+    "go/ast/astutil",
+  ]
+  pruneopts = "UT"
   revision = "8026fb003c560896db954319ee6d037f22a8d9c7"
 
 [[projects]]
+  digest = "1:0f287957ae25f63e6a9fa361923581db8551e38d6b5e6c4f27e84607b3430889"
   name = "gopkg.in/square/go-jose.v2"
-  packages = [".","cipher","json"]
+  packages = [
+    ".",
+    "cipher",
+    "json",
+  ]
+  pruneopts = "UT"
   revision = "76dd09796242edb5b897103a75df2645c028c960"
   version = "v2.1.6"
 
 [[projects]]
+  digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "25bd4fb4732b834c585f86e7846b914d51a4d385ed6a76034161f30f0f7cfaa1"
+  input-imports = [
+    "github.com/Unleash/unleash-client-go",
+    "github.com/Unleash/unleash-client-go/context",
+    "github.com/dgrijalva/jwt-go",
+    "github.com/dgrijalva/jwt-go/request",
+    "github.com/dnaeon/go-vcr/cassette",
+    "github.com/dnaeon/go-vcr/recorder",
+    "github.com/fabric8-services/fabric8-auth/design",
+    "github.com/fabric8-services/fabric8-auth/errors",
+    "github.com/fabric8-services/fabric8-wit/errors",
+    "github.com/fabric8-services/fabric8-wit/goamiddleware",
+    "github.com/fabric8-services/fabric8-wit/log",
+    "github.com/fabric8-services/fabric8-wit/resource",
+    "github.com/fabric8-services/fabric8-wit/rest",
+    "github.com/goadesign/goa",
+    "github.com/goadesign/goa/client",
+    "github.com/goadesign/goa/cors",
+    "github.com/goadesign/goa/design",
+    "github.com/goadesign/goa/design/apidsl",
+    "github.com/goadesign/goa/encoding/form",
+    "github.com/goadesign/goa/goagen",
+    "github.com/goadesign/goa/goagen/codegen",
+    "github.com/goadesign/goa/goagen/gen_app",
+    "github.com/goadesign/goa/goagen/gen_client",
+    "github.com/goadesign/goa/goagen/gen_controller",
+    "github.com/goadesign/goa/goagen/gen_swagger",
+    "github.com/goadesign/goa/goagen/utils",
+    "github.com/goadesign/goa/goatest",
+    "github.com/goadesign/goa/logging/logrus",
+    "github.com/goadesign/goa/middleware",
+    "github.com/goadesign/goa/middleware/gzip",
+    "github.com/goadesign/goa/middleware/security/jwt",
+    "github.com/goadesign/goa/uuid",
+    "github.com/jinzhu/gorm",
+    "github.com/jstemmer/go-junit-report",
+    "github.com/jteeuwen/go-bindata/go-bindata",
+    "github.com/lib/pq",
+    "github.com/pkg/errors",
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/satori/go.uuid",
+    "github.com/sirupsen/logrus",
+    "github.com/spf13/viper",
+    "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/require",
+    "github.com/stretchr/testify/suite",
+    "github.com/wadey/gocovmerge",
+    "golang.org/x/crypto/openpgp",
+    "golang.org/x/net/context",
+    "gopkg.in/square/go-jose.v2",
+    "gopkg.in/yaml.v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/controller/tenant.go
+++ b/controller/tenant.go
@@ -119,7 +119,7 @@ func (c *TenantController) Setup(ctx *app.SetupTenantContext) error {
 		err = openshift.RawInitTenant(
 			ctx,
 			openshiftConfig,
-			InitTenant(ctx, openshiftConfig.MasterURL, c.tenantService, t),
+			InitTenant(ctx, openshiftConfig.MasterURL, c.tenantService, t, openshiftUsername),
 			openshiftUsername,
 			openshiftUserToken,
 			c.templateVars)
@@ -197,7 +197,7 @@ func (c *TenantController) Update(ctx *app.UpdateTenantContext) error {
 		err = openshift.RawUpdateTenant(
 			ctx,
 			openshiftConfig,
-			InitTenant(ctx, openshiftConfig.MasterURL, c.tenantService, t),
+			InitTenant(ctx, openshiftConfig.MasterURL, c.tenantService, t, openshiftUsername),
 			openshiftUsername,
 			c.templateVars)
 
@@ -292,9 +292,10 @@ func (c *TenantController) Show(ctx *app.ShowTenantContext) error {
 }
 
 // InitTenant is a Callback that assumes a new tenant is being created
-func InitTenant(ctx context.Context, masterURL string, service tenant.Service, currentTenant *tenant.Tenant) openshift.Callback {
+func InitTenant(ctx context.Context, masterURL string, service tenant.Service, currentTenant *tenant.Tenant, openshiftUsername string) openshift.Callback {
 	var maxResourceQuotaStatusCheck int32 = 50 // technically a global retry count across all ResourceQuota on all Tenant Namespaces
 	var currentResourceQuotaStatusCheck int32  // default is 0
+	username := openshift.CreateName(openshiftUsername)
 	return func(statusCode int, method string, request, response map[interface{}]interface{}) (string, map[interface{}]interface{}) {
 		log.Info(ctx, map[string]interface{}{
 			"status":      statusCode,
@@ -328,7 +329,7 @@ func InitTenant(ctx context.Context, masterURL string, service tenant.Service, c
 					Name:      name,
 					State:     "created",
 					Version:   openshift.GetLabelVersion(request),
-					Type:      tenant.GetNamespaceType(name),
+					Type:      tenant.GetNamespaceType(name, username),
 					MasterURL: masterURL,
 				})
 
@@ -343,7 +344,7 @@ func InitTenant(ctx context.Context, masterURL string, service tenant.Service, c
 					Name:      name,
 					State:     "created",
 					Version:   openshift.GetLabelVersion(request),
-					Type:      tenant.GetNamespaceType(name),
+					Type:      tenant.GetNamespaceType(name, username),
 					MasterURL: masterURL,
 				})
 			} else if openshift.GetKind(request) == openshift.ValKindResourceQuota {

--- a/openshift/init_tenant.go
+++ b/openshift/init_tenant.go
@@ -22,8 +22,8 @@ const (
 	varKeycloakURL           = "KEYCLOAK_URL"
 )
 
-func RawInitTenant(ctx context.Context, config Config, callback Callback, username, usertoken string, templateVars map[string]string) error {
-	templs, err := LoadProcessedTemplates(ctx, config, username, templateVars)
+func RawInitTenant(ctx context.Context, config Config, callback Callback, openshiftUsername, usertoken string, templateVars map[string]string) error {
+	templs, err := LoadProcessedTemplates(ctx, config, openshiftUsername, templateVars)
 	if err != nil {
 		return err
 	}
@@ -36,8 +36,9 @@ func RawInitTenant(ctx context.Context, config Config, callback Callback, userna
 	userOpts := ApplyOptions{Config: config.WithToken(usertoken), Callback: callback}
 	var wg sync.WaitGroup
 	wg.Add(len(mapped))
+	username := CreateName(openshiftUsername)
 	for key, val := range mapped {
-		namespaceType := tenant.GetNamespaceType(key)
+		namespaceType := tenant.GetNamespaceType(key, username)
 		if namespaceType == tenant.TypeUser {
 			go func(namespace string, objects []map[interface{}]interface{}, opts, userOpts ApplyOptions) {
 				defer wg.Done()

--- a/tenant/tenant.go
+++ b/tenant/tenant.go
@@ -43,6 +43,7 @@ const (
 	TypeStage   NamespaceType = "stage"
 	TypeRun     NamespaceType = "run"
 	TypeUser    NamespaceType = "user"
+	TypeCustom  NamespaceType = "custom"
 )
 
 // Tenant is the owning OpenShift account
@@ -83,7 +84,10 @@ func (m Namespace) TableName() string {
 }
 
 // GetNamespaceType attempts to extract the namespace type based on namespace name
-func GetNamespaceType(name string) NamespaceType {
+func GetNamespaceType(name, username string) NamespaceType {
+	if name == username {
+		return TypeUser
+	}
 	if strings.HasSuffix(name, "-jenkins") {
 		return TypeJenkins
 	}
@@ -99,5 +103,5 @@ func GetNamespaceType(name string) NamespaceType {
 	if strings.HasSuffix(name, "-run") {
 		return TypeRun
 	}
-	return TypeUser
+	return TypeCustom
 }

--- a/tenant/tenant_test.go
+++ b/tenant/tenant_test.go
@@ -1,0 +1,58 @@
+package tenant_test
+
+import (
+	"github.com/fabric8-services/fabric8-tenant/tenant"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetNamespaceType(t *testing.T) {
+
+	t.Run("should detect ns as user type when has same name", func(t *testing.T) {
+		// when
+		namespaceType := tenant.GetNamespaceType("account-for-test", "account-for-test")
+
+		// then
+		assert.Equal(t, namespaceType, tenant.TypeUser)
+	})
+
+	t.Run("should detect ns as run type when ends with run", func(t *testing.T) {
+		// when
+		namespaceType := tenant.GetNamespaceType("account-for-test-run", "account-for-test")
+
+		// then
+		assert.Equal(t, namespaceType, tenant.TypeRun)
+	})
+
+	t.Run("should detect ns as stage type when ends with stage", func(t *testing.T) {
+		// when
+		namespaceType := tenant.GetNamespaceType("account-for-test-stage-stage", "account-for-stage")
+
+		// then
+		assert.Equal(t, namespaceType, tenant.TypeStage)
+	})
+
+	t.Run("should detect ns as che type when ends with che", func(t *testing.T) {
+		// when
+		namespaceType := tenant.GetNamespaceType("che-che", "che")
+
+		// then
+		assert.Equal(t, namespaceType, tenant.TypeChe)
+	})
+
+	t.Run("should detect ns as jenkins type when ends with jenkins", func(t *testing.T) {
+		// when
+		namespaceType := tenant.GetNamespaceType("any-run-stage-jenkins", "any-run-stage")
+
+		// then
+		assert.Equal(t, namespaceType, tenant.TypeJenkins)
+	})
+
+	t.Run("should detect ns as custom type when ends with unknown suffix", func(t *testing.T) {
+		// when
+		namespaceType := tenant.GetNamespaceType("any-run-stage-custom", "any-run-stage")
+
+		// then
+		assert.Equal(t, namespaceType, tenant.TypeCustom)
+	})
+}


### PR DESCRIPTION
fix to cover the cases when a username ends with any of `-run` `-stage` `-test` `-che `-jenkins` suffixes. otherwise, the tenant service assumes that the user namespace (that has the same name as the username is) is of any other type than the user one.