### PR TITLE
Use sha of latest commit that changes a template file as its version

### DIFF
--- a/.make/Makefile.lnx
+++ b/.make/Makefile.lnx
@@ -1,3 +1,6 @@
+ # Use bash syntax
+SHELL := /bin/bash
+
 BINARY_SERVER_BIN=$(INSTALL_PREFIX)/fabric8-tenant
 DEP_BIN=dep
 GOAGEN_BIN=$(VENDOR_DIR)/github.com/goadesign/goa/goagen/goagen

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -142,6 +142,7 @@ $(eval FLAG=$(1))
   	>&2 echo ERROR: the sha $${TEMPLATE_SHA} of the file $${TEMPLATE_FILE} is not the latest one; \
   	exit 1; \
   fi; \
+  echo SHA of $${TEMPLATE_FILE}: $${TEMPLATE_SHA}; \
 fi;
 endef
 

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -159,7 +159,7 @@ test-unit: test-templates-flags prebuild-check clean-coverage-unit $(COV_PATH_UN
 
 .PHONY: test-unit-no-coverage
 ## Runs the unit tests and WITHOUT producing coverage files for each package.
-test-unit-no-coverage: test-templates-flags test-templates-flags prebuild-check $(SOURCES)
+test-unit-no-coverage: test-templates-flags prebuild-check $(SOURCES)
 	$(call log-info,"Running test: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
 	F8_DEVELOPER_MODE_ENABLED=1 F8_RESOURCE_UNIT_TEST=1 go test -v $(TEST_PACKAGES)

--- a/controller/tenant.go
+++ b/controller/tenant.go
@@ -84,7 +84,7 @@ func (c *TenantController) Setup(ctx *app.SetupTenantContext) error {
 	}
 
 	// create openshift config
-	openshiftConfig := openshift.NewConfig(c.config, user.UserData, cluster.User, cluster.Token, cluster.APIURL, Commit)
+	openshiftConfig := openshift.NewConfig(c.config, user.UserData, cluster.User, cluster.Token, cluster.APIURL)
 	tenant := &tenant.Tenant{
 		ID:         ttoken.Subject(),
 		Email:      ttoken.Email(),
@@ -152,7 +152,7 @@ func (c *TenantController) Update(ctx *app.UpdateTenantContext) error {
 	}
 
 	// create openshift config
-	openshiftConfig := openshift.NewConfig(c.config, user.UserData, cluster.User, cluster.Token, cluster.APIURL, Commit)
+	openshiftConfig := openshift.NewConfig(c.config, user.UserData, cluster.User, cluster.Token, cluster.APIURL)
 
 	// update tenant config
 	tenant.OSUsername = user.OpenshiftUsername
@@ -214,7 +214,7 @@ func (c *TenantController) Clean(ctx *app.CleanTenantContext) error {
 	}
 
 	// create openshift config
-	openshiftConfig := openshift.NewConfig(c.config, user.UserData, cluster.User, cluster.Token, cluster.APIURL, Commit)
+	openshiftConfig := openshift.NewConfig(c.config, user.UserData, cluster.User, cluster.Token, cluster.APIURL)
 
 	err = openshift.CleanTenant(ctx, openshiftConfig, user.OpenshiftUsername, removeFromCluster)
 	if err != nil {

--- a/environment/template.go
+++ b/environment/template.go
@@ -52,6 +52,7 @@ const (
 	varProjectAdminUser      = "PROJECT_ADMIN_USER"
 	varKeycloakURL           = "KEYCLOAK_URL"
 	varCommit                = "COMMIT"
+	varDeployType            = "DEPLOY_TYPE"
 	varKeycloakOsoEndpoint   = "KEYCLOAK_OSO_ENDPOINT"
 	varKeycloakGHEndpoint    = "KEYCLOAK_GITHUB_ENDPOINT"
 )
@@ -84,9 +85,6 @@ type Template struct {
 }
 
 var (
-	stageParams       = map[string]string{"DEPLOY_TYPE": "stage"}
-	runParams         = map[string]string{"DEPLOY_TYPE": "run"}
-	noParams          map[string]string
 	specialCharRegexp = regexp.MustCompile("[^a-z0-9]")
 	variableRegexp    = regexp.MustCompile(`\${([A-Z_0-9]+)}`)
 )
@@ -152,7 +150,7 @@ func (t *Template) ReplaceVars(variables map[string]string) (string, error) {
 	})), nil
 }
 
-func CollectVars(user, masterUser, commit string, config *configuration.Data) map[string]string {
+func CollectVars(user, masterUser string, config *configuration.Data) map[string]string {
 	userName := RetrieveUserName(user)
 
 	vars := map[string]string{
@@ -160,7 +158,6 @@ func CollectVars(user, masterUser, commit string, config *configuration.Data) ma
 		varProjectUser:           user,
 		varProjectRequestingUser: user,
 		varProjectAdminUser:      masterUser,
-		varCommit:                commit,
 	}
 
 	return merge(vars, getVariables(config))

--- a/environment/template_test.go
+++ b/environment/template_test.go
@@ -158,7 +158,7 @@ func TestSort(t *testing.T) {
 	defer reset()
 
 	template := environment.Template{Content: sortTemplate}
-	objects, err := template.Process(environment.CollectVars("developer", "master", "123", data))
+	objects, err := template.Process(environment.CollectVars("developer", "master", data))
 
 	// when
 	sort.Sort(environment.ByKind(objects))
@@ -180,7 +180,7 @@ func TestParseNamespace(t *testing.T) {
 	template := environment.Template{Content: parseNamespaceTemplate}
 
 	// when
-	objects, err := template.Process(environment.CollectVars("developer", "master", "123", data))
+	objects, err := template.Process(environment.CollectVars("developer", "master", data))
 
 	// then
 	require.NoError(t, err)

--- a/main.go
+++ b/main.go
@@ -166,24 +166,38 @@ func checkTemplateVersions() string {
 	errorMsg := ""
 	if environment.VersionFabric8TenantUserFile == "" {
 		errorMsg = errorMsg + createNotSetVersionError("VersionFabric8TenantUserFile")
+	} else {
+		logVersionInfo("fabric8-tenant-user.yml", environment.VersionFabric8TenantUserFile)
 	}
 	if environment.VersionFabric8TenantJenkinsFile == "" {
 		errorMsg = errorMsg + createNotSetVersionError("VersionFabric8TenantJenkinsFile")
+	} else {
+		logVersionInfo("fabric8-tenant-jenkins.yml", environment.VersionFabric8TenantJenkinsFile)
 	}
 	if environment.VersionFabric8TenantDeployFile == "" {
 		errorMsg = errorMsg + createNotSetVersionError("VersionFabric8TenantDeployFile")
+	} else {
+		logVersionInfo("fabric8-tenant-deploy.yml", environment.VersionFabric8TenantDeployFile)
 	}
 	if environment.VersionFabric8TenantCheMtFile == "" {
 		errorMsg = errorMsg + createNotSetVersionError("VersionFabric8TenantCheMtFile")
+	} else {
+		logVersionInfo("fabric8-tenant-che-mt.yml", environment.VersionFabric8TenantCheMtFile)
 	}
 	if environment.VersionFabric8TenantCheFile == "" {
 		errorMsg = errorMsg + createNotSetVersionError("VersionFabric8TenantCheFile")
+	} else {
+		logVersionInfo("fabric8-tenant-che.yml", environment.VersionFabric8TenantCheFile)
 	}
 	return errorMsg
 }
 
 func createNotSetVersionError(variable string) string {
 	return fmt.Sprintf("The variable %s representing a template version is not set.\n", variable)
+}
+
+func logVersionInfo(target, version string) {
+	log.Logger().Infof("Using %s of version: %s", target, version)
 }
 
 func connect(config *configuration.Data) *gorm.DB {

--- a/main.go
+++ b/main.go
@@ -6,12 +6,14 @@ import (
 	"os"
 	"time"
 
+	"fmt"
 	"github.com/fabric8-services/fabric8-common/log"
 	"github.com/fabric8-services/fabric8-tenant/app"
 	"github.com/fabric8-services/fabric8-tenant/auth"
 	"github.com/fabric8-services/fabric8-tenant/cluster"
 	"github.com/fabric8-services/fabric8-tenant/configuration"
 	"github.com/fabric8-services/fabric8-tenant/controller"
+	"github.com/fabric8-services/fabric8-tenant/environment"
 	"github.com/fabric8-services/fabric8-tenant/jsonapi"
 	"github.com/fabric8-services/fabric8-tenant/migration"
 	"github.com/fabric8-services/fabric8-tenant/openshift"
@@ -45,6 +47,11 @@ func main() {
 		logrus.Panic(nil, map[string]interface{}{
 			"err": err,
 		}, "failed to setup the configuration")
+	}
+
+	errorMsg := checkTemplateVersions()
+	if errorMsg != "" {
+		log.Panic(nil, map[string]interface{}{}, errorMsg)
 	}
 
 	db := connect(config)
@@ -153,6 +160,30 @@ func main() {
 		}, "unable to connect to server")
 		service.LogError("startup", "err", err)
 	}
+}
+
+func checkTemplateVersions() string {
+	errorMsg := ""
+	if environment.VersionFabric8TenantUserFile == "" {
+		errorMsg = errorMsg + createNotSetVersionError("VersionFabric8TenantUserFile")
+	}
+	if environment.VersionFabric8TenantJenkinsFile == "" {
+		errorMsg = errorMsg + createNotSetVersionError("VersionFabric8TenantJenkinsFile")
+	}
+	if environment.VersionFabric8TenantDeployFile == "" {
+		errorMsg = errorMsg + createNotSetVersionError("VersionFabric8TenantDeployFile")
+	}
+	if environment.VersionFabric8TenantCheMtFile == "" {
+		errorMsg = errorMsg + createNotSetVersionError("VersionFabric8TenantCheMtFile")
+	}
+	if environment.VersionFabric8TenantCheFile == "" {
+		errorMsg = errorMsg + createNotSetVersionError("VersionFabric8TenantCheFile")
+	}
+	return errorMsg
+}
+
+func createNotSetVersionError(variable string) string {
+	return fmt.Sprintf("The variable %s representing a template version is not set.\n", variable)
 }
 
 func connect(config *configuration.Data) *gorm.DB {

--- a/openshift/apply_test.go
+++ b/openshift/apply_test.go
@@ -140,7 +140,7 @@ func TestDeleteAndGet(t *testing.T) {
 
 func prepareObjectsAndOpts(t *testing.T, content string, config *configuration.Data) (environment.Objects, openshift.ApplyOptions) {
 	template := environment.Template{Content: content}
-	objects, err := template.Process(environment.CollectVars("aslak", "master", "123", config))
+	objects, err := template.Process(environment.CollectVars("aslak", "master", config))
 	require.NoError(t, err)
 	opts := openshift.ApplyOptions{
 		Config: openshift.Config{

--- a/openshift/config.go
+++ b/openshift/config.go
@@ -19,14 +19,13 @@ type Config struct {
 	HTTPTransport     http.RoundTripper
 	ConsoleURL        string
 	LogCallback       LogCallback
-	Commit            string
 	TemplatesRepo     string
 	TemplatesRepoBlob string
 	TemplatesRepoDir  string
 }
 
 // NewConfig builds openshift config for every user request depending on the user profile
-func NewConfig(config *configuration.Data, user *authclient.UserDataAttributes, clusterUser, clusterToken, clusterURL, commit string) Config {
+func NewConfig(config *configuration.Data, user *authclient.UserDataAttributes, clusterUser, clusterToken, clusterURL string) Config {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: config.APIServerInsecureSkipTLSVerify(),
@@ -40,7 +39,6 @@ func NewConfig(config *configuration.Data, user *authclient.UserDataAttributes, 
 		MasterUser:     clusterUser,
 		Token:          clusterToken,
 		MasterURL:      clusterURL,
-		Commit:         commit,
 	}
 	return setTemplateRepoInfo(user, conf)
 }

--- a/openshift/init_tenant_test.go
+++ b/openshift/init_tenant_test.go
@@ -32,7 +32,7 @@ func TestNumberOfCallsToCluster(t *testing.T) {
 		BodyString("{}")
 
 	user := &client.UserDataAttributes{}
-	config := openshift.NewConfig(data, user, "clusterUser", "clusterToken", "http://my.cluster", "1a2b")
+	config := openshift.NewConfig(data, user, "clusterUser", "clusterToken", "http://my.cluster")
 	config.HTTPTransport = http.DefaultTransport
 	objectsInTemplates := tmplObjects(t, data)
 

--- a/openshift/process_template.go
+++ b/openshift/process_template.go
@@ -46,7 +46,7 @@ func IsNotOfKind(kinds ...string) FilterFunc {
 func LoadProcessedTemplates(ctx context.Context, config Config, username string) (environment.Objects, error) {
 
 	envService := environment.NewService(config.TemplatesRepo, config.TemplatesRepoBlob, config.TemplatesRepoDir)
-	vars := environment.CollectVars(username, config.MasterUser, config.Commit, config.OriginalConfig)
+	vars := environment.CollectVars(username, config.MasterUser, config.OriginalConfig)
 	var objs environment.Objects
 
 	for _, envType := range environment.DefaultEnvTypes {


### PR DESCRIPTION
This PR is a followup of a PR https://github.com/fabric8-services/fabric8-tenant/pull/634. It changes the template versioning system to a form we agreed on in a mailing thread - that as a template version a `sha` of the latest commit that changes the particular file is used. This is set by `LDFLAGS`. The correct creation of the `LDFLAGS` is verified by a test that is executed as part of `test-unit` target: