### PR TITLE
Add comment redirecting to _tenant page to every PR changing a template

### DIFF
--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -97,6 +97,17 @@ function run_tests_with_coverage() {
   echo "CICO: ran tests and uploaded coverage"
 }
 
+function addCommentToPullRequest() {
+    link="[OpenShift.io](https://openshift.io/_profile/_tenant?templatesRepoBlob=${ghprbActualCommit})"
+    message="This PR changes one or more of the template files. These changes are now available for testing: Launch in ${link} and click the update tenant button"
+    url="https://api.github.com/repos/fabric8-services/fabric8-tenant/issues/${ghprbPullId}/comments"
+
+    set +x
+    echo curl -X POST -s -L -H "Authorization: XXXX|base64 --decode)" ${url} -d "{\"body\": \"${message}\"}"
+    curl -X POST -s -L -H "Authorization: token $(echo ${FABRIC8_HUB_TOKEN}|base64 --decode)" ${url} -d "{\"body\": \"${message}\"}"
+    set -x
+}
+
 function tag_push() {
   local tag=$1
   docker tag fabric8-tenant-deploy $tag
@@ -130,5 +141,8 @@ function deploy() {
 function cico_setup() {
   load_jenkins_vars;
   install_deps;
+  if [[ -n `git diff --name-only ${ghprbActualCommit}..master | grep "environment/templates/"` ]]; then
+    addCommentToPullRequest;
+  fi
   prepare;
 }


### PR DESCRIPTION
When there is a PR that changes any of the templates, then the script will add a comment looking like:
![obrazek](https://user-images.githubusercontent.com/1510709/46416060-049f4980-c727-11e8-900f-ee27c9323cb4.png)

This PR depends on: https://github.com/openshiftio/openshiftio-cico-jobs/pull/835 that enables an access to the necessary secret token
