### PR TITLE
feat(#652): introduce version-quotas label in che and jenkins templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ SOURCE_DIR ?= .
 SOURCES := $(shell find $(SOURCE_DIR) -path $(SOURCE_DIR)/vendor -prune -o -name '*.go' -print)
 DESIGN_DIR=design
 DESIGNS := $(shell find $(SOURCE_DIR)/$(DESIGN_DIR) -path $(SOURCE_DIR)/vendor -prune -o -name '*.go' -print)
-TEMPLATES := $(shell find $(SOURCE_DIR)/environment/templates -type f ! -name *quotas*)
+TEMPLATES := $(shell find $(SOURCE_DIR)/environment/templates -type f)
 
 # Find all required tools:
 GIT_BIN := $(shell command -v $(GIT_BIN_NAME) 2> /dev/null)

--- a/environment/service.go
+++ b/environment/service.go
@@ -25,27 +25,32 @@ const (
 )
 
 var (
-	VersionFabric8TenantUserFile    string
-	VersionFabric8TenantCheMtFile   string
-	VersionFabric8TenantJenkinsFile string
-	VersionFabric8TenantCheFile     string
-	VersionFabric8TenantDeployFile  string
-	DefaultEnvTypes                 = []string{"che", "jenkins", "user", "run", "stage"}
+	VersionFabric8TenantUserFile          string
+	VersionFabric8TenantCheMtFile         string
+	VersionFabric8TenantJenkinsFile       string
+	VersionFabric8TenantJenkinsQuotasFile string
+	VersionFabric8TenantCheFile           string
+	VersionFabric8TenantCheQuotasFile     string
+	VersionFabric8TenantDeployFile        string
+	DefaultEnvTypes                       = []string{"che", "jenkins", "user", "run", "stage"}
 )
 
 func retrieveMappedTemplates() map[string][]*Template {
 	return map[string][]*Template{
-		"run":     tmpls(deploy("run"), "fabric8-tenant-deploy.yml"),
-		"stage":   tmpls(deploy("stage"), "fabric8-tenant-deploy.yml"),
-		"che-mt":  tmpls(version(VersionFabric8TenantCheMtFile), "fabric8-tenant-che-mt.yml", "fabric8-tenant-che-quotas.yml"),
-		"che":     tmpls(version(VersionFabric8TenantCheFile), "fabric8-tenant-che.yml", "fabric8-tenant-che-quotas.yml"),
-		"jenkins": tmpls(version(VersionFabric8TenantJenkinsFile), "fabric8-tenant-jenkins.yml", "fabric8-tenant-jenkins-quotas.yml"),
-		"user":    tmpls(version(VersionFabric8TenantUserFile), "fabric8-tenant-user.yml"),
+		"run":   tmpls(deploy("run"), "fabric8-tenant-deploy.yml"),
+		"stage": tmpls(deploy("stage"), "fabric8-tenant-deploy.yml"),
+		"che-mt": tmpls(versions(VersionFabric8TenantCheMtFile, VersionFabric8TenantCheQuotasFile),
+			"fabric8-tenant-che-mt.yml", "fabric8-tenant-che-quotas.yml"),
+		"che": tmpls(versions(VersionFabric8TenantCheFile, VersionFabric8TenantCheQuotasFile),
+			"fabric8-tenant-che.yml", "fabric8-tenant-che-quotas.yml"),
+		"jenkins": tmpls(versions(VersionFabric8TenantJenkinsFile, VersionFabric8TenantJenkinsQuotasFile),
+			"fabric8-tenant-jenkins.yml", "fabric8-tenant-jenkins-quotas.yml"),
+		"user": tmpls(versions(VersionFabric8TenantUserFile, ""), "fabric8-tenant-user.yml"),
 	}
 }
 
-func version(version string) map[string]string {
-	return map[string]string{varCommit: version}
+func versions(version, quotasVersion string) map[string]string {
+	return map[string]string{varCommit: version, varCommitQuotas: quotasVersion}
 }
 
 func deploy(stage string) map[string]string {
@@ -141,6 +146,7 @@ func (s *Service) retrieveTemplates(tmpls []*Template) error {
 			fileURL := fmt.Sprintf(rawFileURLTemplate, s.getRepo(), s.templatesRepoBlob, s.getPath(template))
 			content, err = utils.DownloadFile(fileURL)
 			template.DefaultParams[varCommit] = s.templatesRepoBlob
+			template.DefaultParams[varCommitQuotas] = s.templatesRepoBlob
 		} else {
 			content, err = templates.Asset(template.Filename)
 		}

--- a/environment/service_test.go
+++ b/environment/service_test.go
@@ -28,7 +28,7 @@ objects:
 var customLocationTempl = `apiVersion: v1
 kind: Template
 metadata:
-  name: fabric8-tenant-${DEPLOY_TYPE}
+  name: fabric8-tenant-jenkins
 objects:
 - apiVersion: v1
   kind: ProjectRequest
@@ -36,7 +36,21 @@ objects:
     labels:
       test: custom-location
       version: ${COMMIT}
-    name: ${USER_NAME}-${DEPLOY_TYPE}`
+      version-quotas: ${COMMIT_QUOTAS}
+    name: ${USER_NAME}-jenkins`
+
+var customLocationQuotas = `apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: LimitRange
+  metadata:
+    labels:
+      app: fabric8-tenant-jenkins-quotas
+      provider: fabric8
+      version: ${COMMIT_QUOTAS}
+    name: resource-limits
+    namespace: ${USER_NAME}-jenkins`
 
 func TestGetAllTemplatesForAllTypes(t *testing.T) {
 	// given
@@ -61,21 +75,26 @@ func TestGetAllTemplatesForAllTypes(t *testing.T) {
 			assert.Contains(t, env.Templates[1].Filename, "quotas")
 			if envType == "jenkins" {
 				assert.Equal(t, "567efg", environment.GetLabelVersion(objects[0]))
+				assert.Equal(t, "yxw987", environment.GetLabel(objects[0], environment.FieldVersionQuotas))
 			} else {
 				if strings.Contains(env.Templates[0].Filename, "mt") {
 					assert.Equal(t, "234bcd", environment.GetLabelVersion(objects[0]))
+					assert.Equal(t, "zyx098", environment.GetLabel(objects[0], environment.FieldVersionQuotas))
 				} else {
 					assert.Equal(t, "123abc", environment.GetLabelVersion(objects[0]))
+					assert.Equal(t, "zyx098", environment.GetLabel(objects[0], environment.FieldVersionQuotas))
 				}
 			}
 		} else if envType == "user" {
 			assert.Len(t, env.Templates, 1)
 			assert.Contains(t, env.Templates[0].Filename, envType)
 			assert.Equal(t, "345cde", environment.GetLabelVersion(objects[0]))
+			assert.Empty(t, environment.GetLabel(objects[0], environment.FieldVersionQuotas))
 		} else {
 			assert.Len(t, env.Templates, 1)
 			assert.Contains(t, env.Templates[0].Filename, "deploy")
 			assert.Equal(t, "456def", environment.GetLabelVersion(objects[0]))
+			assert.Empty(t, environment.GetLabel(objects[0], environment.FieldVersionQuotas))
 		}
 
 		for _, template := range env.Templates {
@@ -119,9 +138,11 @@ func TestAllTemplatesHaveNecessaryData(t *testing.T) {
 func setTemplateVersions() {
 	environment.VersionFabric8TenantCheFile = "123abc"
 	environment.VersionFabric8TenantCheMtFile = "234bcd"
+	environment.VersionFabric8TenantCheQuotasFile = "zyx098"
 	environment.VersionFabric8TenantUserFile = "345cde"
 	environment.VersionFabric8TenantDeployFile = "456def"
 	environment.VersionFabric8TenantJenkinsFile = "567efg"
+	environment.VersionFabric8TenantJenkinsQuotasFile = "yxw987"
 }
 
 func TestDownloadFromGivenBlob(t *testing.T) {
@@ -153,24 +174,36 @@ func TestDownloadFromGivenBlobLocatedInCustomLocation(t *testing.T) {
 	// given
 	defer gock.OffAll()
 	gock.New("http://my.git.com").
-		Get("my-services/my-tenant/blob/987cba/any/path/fabric8-tenant-deploy.yml").
+		Get("my-services/my-tenant/blob/987cba/any/path/fabric8-tenant-jenkins.yml").
 		Reply(200).
 		BodyString(customLocationTempl)
+	gock.New("http://my.git.com").
+		Get("my-services/my-tenant/blob/987cba/any/path/fabric8-tenant-jenkins-quotas.yml").
+		Reply(200).
+		BodyString(customLocationQuotas)
 	setTemplateVersions()
 	service := environment.NewService("http://my.git.com/my-services/my-tenant", "987cba", "any/path")
 
 	// when
-	envData, err := service.GetEnvData(context.Background(), "run")
+	envData, err := service.GetEnvData(context.Background(), "jenkins")
 
 	// then
 	require.NoError(t, err)
 	vars := map[string]string{
 		"USER_NAME": "dev",
 	}
+	assert.Len(t, envData.Templates, 2)
 	objects, err := envData.Templates[0].Process(vars)
 	require.NoError(t, err)
 	assert.Len(t, objects, 1)
 	assert.Equal(t, environment.GetLabel(objects[0], "test"), "custom-location")
+	assert.Equal(t, environment.GetLabelVersion(objects[0]), "987cba")
+	assert.Equal(t, environment.GetLabel(objects[0], environment.FieldVersionQuotas), "987cba")
+
+	objects, err = envData.Templates[1].Process(vars)
+	require.NoError(t, err)
+	assert.Len(t, objects, 1)
+	assert.Empty(t, environment.GetLabel(objects[0], environment.FieldVersionQuotas))
 	assert.Equal(t, environment.GetLabelVersion(objects[0]), "987cba")
 }
 

--- a/environment/template.go
+++ b/environment/template.go
@@ -22,6 +22,7 @@ const (
 	FieldLabels          = "labels"
 	FieldReplicas        = "replicas"
 	FieldVersion         = "version"
+	FieldVersionQuotas   = "version-quotas"
 	FieldNamespace       = "namespace"
 	FieldName            = "name"
 	FieldStatus          = "status"
@@ -53,6 +54,7 @@ const (
 	varProjectAdminUser      = "PROJECT_ADMIN_USER"
 	varKeycloakURL           = "KEYCLOAK_URL"
 	varCommit                = "COMMIT"
+	varCommitQuotas          = "COMMIT_QUOTAS"
 	varDeployType            = "DEPLOY_TYPE"
 	varKeycloakOsoEndpoint   = "KEYCLOAK_OSO_ENDPOINT"
 	varKeycloakGHEndpoint    = "KEYCLOAK_GITHUB_ENDPOINT"
@@ -83,7 +85,6 @@ type Template struct {
 	Filename      string
 	DefaultParams map[string]string
 	Content       string
-	Version       string
 }
 
 var (
@@ -112,7 +113,6 @@ func (t *Template) Process(vars map[string]string) (Objects, error) {
 	if err != nil {
 		return objects, err
 	}
-	t.Version = vars[varCommit]
 	return ParseObjects(pt)
 }
 

--- a/environment/templates/fabric8-tenant-che-mt.yml
+++ b/environment/templates/fabric8-tenant-che-mt.yml
@@ -19,6 +19,7 @@ objects:
       app: fabric8-tenant-che
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: ${USER_NAME}-che
 - apiVersion: v1
   kind: RoleBindingRestriction
@@ -27,6 +28,7 @@ objects:
       app: fabric8-tenant-che-mt
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: dsaas-user-access
     namespace: ${USER_NAME}-che
   spec:
@@ -40,6 +42,7 @@ objects:
       app: fabric8-tenant-che-mt
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: che
     namespace: ${USER_NAME}-che
 - apiVersion: v1
@@ -49,6 +52,7 @@ objects:
       app: fabric8-tenant-che-mt
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: che-workspace
     namespace: ${USER_NAME}-che
 - apiVersion: v1
@@ -58,6 +62,7 @@ objects:
       app: fabric8-tenant-che-mt
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: exec
     namespace: ${USER_NAME}-che
   rules:
@@ -74,6 +79,7 @@ objects:
       app: fabric8-tenant-che-mt
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: che-edit
     namespace: ${USER_NAME}-che
   roleRef:
@@ -88,6 +94,7 @@ objects:
       app: fabric8-tenant-che-mt
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: user-edit
     namespace: ${USER_NAME}-che
   roleRef:
@@ -104,6 +111,7 @@ objects:
       app: fabric8-tenant-che-mt
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: user-exec
     namespace: ${USER_NAME}-che
   roleRef:
@@ -121,6 +129,7 @@ objects:
       app: fabric8-tenant-che-mt
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: user-view
     namespace: ${USER_NAME}-che
   roleRef:
@@ -137,6 +146,7 @@ objects:
       app: fabric8-tenant-che-mt
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: workspace-exec
     namespace: ${USER_NAME}-che
   roleRef:
@@ -152,6 +162,7 @@ objects:
       app: fabric8-tenant-che-mt
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: workspace-view
     namespace: ${USER_NAME}-che
   roleRef:
@@ -166,6 +177,7 @@ objects:
       app: fabric8-tenant-che-mt
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: claim-che-workspace
     namespace: ${USER_NAME}-che
   spec:
@@ -186,4 +198,6 @@ parameters:
   generate: expression
   name: JOB_ID
 - name: COMMIT
+  value: 123abc
+- name: COMMIT_QUOTAS
   value: 123abc

--- a/environment/templates/fabric8-tenant-che-quotas.yml
+++ b/environment/templates/fabric8-tenant-che-quotas.yml
@@ -8,7 +8,7 @@ items:
     labels:
       app: fabric8-tenant-che-quotas
       provider: fabric8
-      version: ${COMMIT}
+      version: ${COMMIT_QUOTAS}
     name: resource-limits
     namespace: ${USER_NAME}-che
   spec:
@@ -44,7 +44,7 @@ items:
     labels:
       app: fabric8-tenant-che-quotas
       provider: fabric8
-      version: ${COMMIT}
+      version: ${COMMIT_QUOTAS}
     name: compute-resources
     namespace: ${USER_NAME}-che
   spec:
@@ -59,7 +59,7 @@ items:
     labels:
       app: fabric8-tenant-che-quotas
       provider: fabric8
-      version: ${COMMIT}
+      version: ${COMMIT_QUOTAS}
     name: compute-resources-timebound
     namespace: ${USER_NAME}-che
   spec:
@@ -74,7 +74,7 @@ items:
     labels:
       app: fabric8-tenant-che-quotas
       provider: fabric8
-      version: ${COMMIT}
+      version: ${COMMIT_QUOTAS}
     name: object-counts
     namespace: ${USER_NAME}-che
   spec:
@@ -86,3 +86,5 @@ items:
 parameters:
 - name: USER_NAME
   value: developer
+- name: COMMIT_QUOTAS
+  value: 123abc

--- a/environment/templates/fabric8-tenant-che.yml
+++ b/environment/templates/fabric8-tenant-che.yml
@@ -19,6 +19,7 @@ objects:
       app: fabric8-tenant-che
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: ${USER_NAME}-che
 - apiVersion: v1
   kind: RoleBindingRestriction
@@ -27,6 +28,7 @@ objects:
       app: fabric8-tenant-che
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: dsaas-user-access
     namespace: ${USER_NAME}-che
   spec:
@@ -40,6 +42,7 @@ objects:
       app: fabric8-tenant-che
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: che-recommender-api-token
     namespace: ${USER_NAME}-che
   data:
@@ -52,6 +55,7 @@ objects:
       app: fabric8-tenant-che
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: che
     namespace: ${USER_NAME}-che
 - apiVersion: v1
@@ -64,6 +68,7 @@ objects:
       provider: fabric8
       expose: "false"
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: che-host
     namespace: ${USER_NAME}-che
   spec:
@@ -82,6 +87,7 @@ objects:
       app: fabric8-tenant-che
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: che
     namespace: ${USER_NAME}-che
   roleRef:
@@ -96,6 +102,7 @@ objects:
       app: fabric8-tenant-che
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: user-edit
     namespace: ${USER_NAME}-che
   roleRef:
@@ -112,6 +119,7 @@ objects:
       app: fabric8-tenant-che
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: user-view
     namespace: ${USER_NAME}-che
   roleRef:
@@ -128,6 +136,7 @@ objects:
       app: che
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: che-data-volume
     namespace: ${USER_NAME}-che
   spec:
@@ -143,6 +152,7 @@ objects:
       app: che
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: claim-che-workspace
     namespace: ${USER_NAME}-che
   spec:
@@ -158,6 +168,7 @@ objects:
       app: che
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: che
     namespace: ${USER_NAME}-che
   data:
@@ -204,6 +215,7 @@ objects:
       fabric8.io/kind: package
       provider: fabric8.io
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
       app: fabric8-tenant-che
     name: fabric8-online-che
     namespace: ${USER_NAME}-che
@@ -217,6 +229,7 @@ objects:
       app: che
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: che
     namespace: ${USER_NAME}-che
   spec:
@@ -235,6 +248,7 @@ objects:
           app: che
           provider: fabric8
           version: ${COMMIT}
+          version-quotas: ${COMMIT_QUOTAS}
       spec:
         containers:
         - env:
@@ -446,6 +460,7 @@ objects:
       app: che
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: che
     namespace: ${USER_NAME}-che
   spec:
@@ -478,4 +493,6 @@ parameters:
 - name: CHE_KEYCLOAK_CLIENT__ID
   value: openshiftio-public
 - name: COMMIT
+  value: 123abc
+- name: COMMIT_QUOTAS
   value: 123abc

--- a/environment/templates/fabric8-tenant-jenkins-quotas.yml
+++ b/environment/templates/fabric8-tenant-jenkins-quotas.yml
@@ -8,7 +8,7 @@ items:
     labels:
       app: fabric8-tenant-jenkins-quotas
       provider: fabric8
-      version: ${COMMIT}
+      version: ${COMMIT_QUOTAS}
     name: resource-limits
     namespace: ${USER_NAME}-jenkins
   spec:
@@ -44,7 +44,7 @@ items:
     labels:
       app: fabric8-tenant-jenkins-quotas
       provider: fabric8
-      version: ${COMMIT}
+      version: ${COMMIT_QUOTAS}
     name: compute-resources
     namespace: ${USER_NAME}-jenkins
   spec:
@@ -59,7 +59,7 @@ items:
     labels:
       app: fabric8-tenant-jenkins-quotas
       provider: fabric8
-      version: ${COMMIT}
+      version: ${COMMIT_QUOTAS}
     name: compute-resources-timebound
     namespace: ${USER_NAME}-jenkins
   spec:
@@ -74,7 +74,7 @@ items:
     labels:
       app: fabric8-tenant-jenkins-quotas
       provider: fabric8
-      version: ${COMMIT}
+      version: ${COMMIT_QUOTAS}
     name: object-counts
     namespace: ${USER_NAME}-jenkins
   spec:
@@ -86,3 +86,5 @@ items:
 parameters:
 - name: USER_NAME
   value: developer
+- name: COMMIT_QUOTAS
+  value: 123abc

--- a/environment/templates/fabric8-tenant-jenkins.yml
+++ b/environment/templates/fabric8-tenant-jenkins.yml
@@ -19,6 +19,7 @@ objects:
       app: fabric8-tenant-jenkins
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: ${USER_NAME}-jenkins
 - apiVersion: v1
   kind: RoleBindingRestriction
@@ -27,6 +28,7 @@ objects:
       app: fabric8-tenant-jenkins
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: dsaas-access-sa-ns
     namespace: ${USER_NAME}-jenkins
   spec:
@@ -40,6 +42,7 @@ objects:
       app: fabric8-tenant-jenkins
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: dsaas-user-access
     namespace: ${USER_NAME}-jenkins
   spec:
@@ -53,6 +56,7 @@ objects:
       app: jenkins
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: jenkins-docker-cfg
     namespace: ${USER_NAME}-jenkins
   data:
@@ -65,6 +69,7 @@ objects:
       app: jenkins
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: jenkins-git-ssh
     namespace: ${USER_NAME}-jenkins
   data:
@@ -78,6 +83,7 @@ objects:
       app: jenkins
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: jenkins-hub-api-token
     namespace: ${USER_NAME}-jenkins
   data:
@@ -90,6 +96,7 @@ objects:
       app: jenkins
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: jenkins-maven-settings
     namespace: ${USER_NAME}-jenkins
   data:
@@ -102,6 +109,7 @@ objects:
       app: jenkins
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: jenkins-recommender-api-token
     namespace: ${USER_NAME}-jenkins
   data:
@@ -114,6 +122,7 @@ objects:
       app: jenkins
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: jenkins-release-gpg
     namespace: ${USER_NAME}-jenkins
   data:
@@ -129,6 +138,7 @@ objects:
       app: jenkins
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: jenkins-ssh-config
     namespace: ${USER_NAME}-jenkins
   data:
@@ -141,6 +151,7 @@ objects:
       app: fabric8-tenant-jenkins
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: cd-bot
     namespace: ${USER_NAME}-jenkins
 - apiVersion: v1
@@ -152,6 +163,7 @@ objects:
       app: jenkins
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: jenkins
     namespace: ${USER_NAME}-jenkins
 - apiVersion: v1
@@ -162,6 +174,7 @@ objects:
       app: bayesian-link
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: bayesian-link
     namespace: ${USER_NAME}-jenkins
   spec:
@@ -182,6 +195,7 @@ objects:
       provider: fabric8
       expose: "true"
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: jenkins
     namespace: ${USER_NAME}-jenkins
   spec:
@@ -201,6 +215,7 @@ objects:
       provider: fabric8
       expose: "false"
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: jenkins-jnlp
     namespace: ${USER_NAME}-jenkins
   spec:
@@ -219,6 +234,7 @@ objects:
       app: fabric8-tenant-jenkins
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: edit-jenkins
     namespace: ${USER_NAME}-jenkins
   roleRef:
@@ -233,6 +249,7 @@ objects:
       app: fabric8-tenant-jenkins
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: view
     namespace: ${USER_NAME}-jenkins
   roleRef:
@@ -249,6 +266,7 @@ objects:
       app: fabric8-tenant-jenkins
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: view-cd-bot
     namespace: ${USER_NAME}-jenkins
   roleRef:
@@ -263,6 +281,7 @@ objects:
       app: fabric8-tenant-jenkins
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: view-jenkins
     namespace: ${USER_NAME}-jenkins
   roleRef:
@@ -277,6 +296,7 @@ objects:
       app: jenkins
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: jenkins-home
     namespace: ${USER_NAME}-jenkins
   spec:
@@ -292,6 +312,7 @@ objects:
       fabric8.io/kind: package
       provider: fabric8.io
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
       app: fabric8-tenant-jenkins
     name: fabric8-online-jenkins
     namespace: ${USER_NAME}-jenkins
@@ -307,6 +328,7 @@ objects:
       fabric8.io/kind: space-link
       provider: fabric8.io
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
       app: fabric8-tenant-jenkins
     name: fabric8-space-link
     namespace: ${USER_NAME}-jenkins
@@ -321,6 +343,7 @@ objects:
       app: jenkins
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: jenkins
     namespace: ${USER_NAME}-jenkins
   data:
@@ -679,6 +702,7 @@ objects:
       app: jenkins
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: jenkins
     namespace: ${USER_NAME}-jenkins
   spec:
@@ -699,6 +723,7 @@ objects:
           app: jenkins
           provider: fabric8
           version: ${COMMIT}
+          version-quotas: ${COMMIT_QUOTAS}
       spec:
         containers:
         - env:
@@ -798,6 +823,7 @@ objects:
       app: jenkins
       provider: fabric8
       version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
     name: jenkins
     namespace: ${USER_NAME}-jenkins
   spec:
@@ -821,4 +847,6 @@ parameters:
 - name: FABRIC8_CONSOLE_URL
 - name: JENKINS_ROOT_URL
 - name: COMMIT
+  value: 123abc
+- name: COMMIT_QUOTAS
   value: 123abc

--- a/main.go
+++ b/main.go
@@ -174,6 +174,11 @@ func checkTemplateVersions() string {
 	} else {
 		logVersionInfo("fabric8-tenant-jenkins.yml", environment.VersionFabric8TenantJenkinsFile)
 	}
+	if environment.VersionFabric8TenantJenkinsQuotasFile == "" {
+		errorMsg = errorMsg + createNotSetVersionError("VersionFabric8TenantJenkinsQuotasFile")
+	} else {
+		logVersionInfo("fabric8-tenant-jenkins-quotas.yml", environment.VersionFabric8TenantJenkinsQuotasFile)
+	}
 	if environment.VersionFabric8TenantDeployFile == "" {
 		errorMsg = errorMsg + createNotSetVersionError("VersionFabric8TenantDeployFile")
 	} else {
@@ -188,6 +193,11 @@ func checkTemplateVersions() string {
 		errorMsg = errorMsg + createNotSetVersionError("VersionFabric8TenantCheFile")
 	} else {
 		logVersionInfo("fabric8-tenant-che.yml", environment.VersionFabric8TenantCheFile)
+	}
+	if environment.VersionFabric8TenantCheQuotasFile == "" {
+		errorMsg = errorMsg + createNotSetVersionError("VersionFabric8TenantCheQuotasFile")
+	} else {
+		logVersionInfo("fabric8-tenant-che-quotas.yml", environment.VersionFabric8TenantCheQuotasFile)
 	}
 	return errorMsg
 }


### PR DESCRIPTION
This PR adds `version-quotas` label to all objects in both `-che*-` and `-jenkins-` templates. This label contains version (latest commit `SHA`) of an associated quotas file.

Fixes: #652