### PR TITLE
fix(#655): use raw.githubusercontent.com host for downloading template files

### DIFF
--- a/environment/service.go
+++ b/environment/service.go
@@ -19,8 +19,8 @@ import (
 //go:generate go-bindata -prefix "./templates/" -pkg templates -o ./generated/templates.go ./templates/...
 
 const (
-	f8TenantServiceRepoUrl = "https://github.com/fabric8-services/fabric8-tenant"
-	rawFileURLTemplate     = "%s/blob/%s/%s"
+	f8TenantServiceRepoUrl = "https://raw.githubusercontent.com/fabric8-services/fabric8-tenant"
+	rawFileURLTemplate     = "%s/%s/%s"
 	templatesDirectory     = "environment/templates/"
 )
 
@@ -153,16 +153,20 @@ func (s *Service) retrieveTemplates(tmpls []*Template) error {
 }
 
 func (s *Service) getRepo() string {
-	return get(s.templatesRepo, f8TenantServiceRepoUrl)
+	repo := strings.TrimSpace(s.templatesRepo)
+	if repo == "" {
+		return f8TenantServiceRepoUrl
+	}
+	if strings.Contains(repo, "github.com") {
+		return strings.Replace(repo, "github.com", "raw.githubusercontent.com", 1)
+	}
+	return repo
 }
 
 func (s *Service) getPath(template *Template) string {
-	return path.Clean(get(s.templatesRepoDir, templatesDirectory) + "/" + template.Filename)
-}
-
-func get(value, defaultValue string) string {
-	if strings.TrimSpace(value) == "" {
-		return defaultValue
+	directory := strings.TrimSpace(s.templatesRepoDir)
+	if directory == "" {
+		directory = templatesDirectory
 	}
-	return value
+	return path.Clean(directory + "/" + template.Filename)
 }

--- a/environment/service_test.go
+++ b/environment/service_test.go
@@ -124,11 +124,37 @@ func setTemplateVersions() {
 	environment.VersionFabric8TenantJenkinsFile = "567efg"
 }
 
+// Ignored because it downloads files directly from GitHub
+func XTestDownloadFromExistingLocation(t *testing.T) {
+	// given
+	setTemplateVersions()
+	service := environment.NewService("", "29541ca", "")
+	vars := map[string]string{
+		"USER_NAME": "dev",
+	}
+
+	for _, envType := range environment.DefaultEnvTypes {
+		// when
+		env, err := service.GetEnvData(context.Background(), envType)
+		require.NoError(t, err)
+
+		for _, template := range env.Templates {
+			objects, err := template.Process(vars)
+			require.NoError(t, err)
+
+			//then
+			for _, obj := range objects {
+				assert.Equal(t, "29541ca", environment.GetLabelVersion(obj), template.Filename)
+			}
+		}
+	}
+}
+
 func TestDownloadFromGivenBlob(t *testing.T) {
 	// given
 	defer gock.OffAll()
-	gock.New("https://github.com").
-		Get("fabric8-services/fabric8-tenant/blob/987654321/environment/templates/fabric8-tenant-deploy.yml").
+	gock.New("https://raw.githubusercontent.com").
+		Get("fabric8-services/fabric8-tenant/987654321/environment/templates/fabric8-tenant-deploy.yml").
 		Reply(200).
 		BodyString(defaultLocationTempl)
 	setTemplateVersions()
@@ -152,12 +178,12 @@ func TestDownloadFromGivenBlob(t *testing.T) {
 func TestDownloadFromGivenBlobLocatedInCustomLocation(t *testing.T) {
 	// given
 	defer gock.OffAll()
-	gock.New("http://my.git.com").
-		Get("my-services/my-tenant/blob/987cba/any/path/fabric8-tenant-deploy.yml").
+	gock.New("http://raw.githubusercontent.com").
+		Get("my-services/my-tenant/987cba/any/path/fabric8-tenant-deploy.yml").
 		Reply(200).
 		BodyString(customLocationTempl)
 	setTemplateVersions()
-	service := environment.NewService("http://my.git.com/my-services/my-tenant", "987cba", "any/path")
+	service := environment.NewService("http://github.com/my-services/my-tenant", "987cba", "any/path")
 
 	// when
 	envData, err := service.GetEnvData(context.Background(), "run")


### PR DESCRIPTION
For downloading templates files (in case of in-production testing) the host `raw.githubusercontent.com` is used. It also checks if the custom repo URL (set in _profile page) contains `github.com` host and replaces it by the correct one.
I have changed the mocked tests to verify the host and also added another test (that is by default excluded) that downloads the templates from a specific blob directly from GitHub - by un-excluding the test it is easy to verify that the downloads are really working