### PR TITLE
chore: improve sentry errors

### DIFF
--- a/auth/service.go
+++ b/auth/service.go
@@ -75,7 +75,7 @@ func (s *Service) GetUser(ctx context.Context) (*User, error) {
 			"err":         err,
 			"cluster_url": *userData.Cluster,
 		}, "unable to fetch tenant token from auth")
-		return nil, commonerrs.NewUnauthorizedError("Could not resolve user token")
+		return nil, commonerrs.NewUnauthorizedError("could not resolve user token. Caused by: " + err.Error())
 	}
 
 	return &User{

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -9,6 +9,7 @@ import (
 	"github.com/fabric8-services/fabric8-tenant/configuration"
 	"github.com/getsentry/raven-go"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
+	"github.com/pkg/errors"
 )
 
 // InitializeLogger initializes sentry client
@@ -40,7 +41,7 @@ func extractUserInfo() func(ctx context.Context) (*raven.User, error) {
 
 // LogError logs the given error and reports it to sentry
 func LogError(ctx context.Context, fields map[string]interface{}, err error, message string) {
-	sentryError := fmt.Errorf("an error occured with a message: \n%s\n with fields: \n%s\n and caused by: \n%s", message, fields, err)
+	sentryError := errors.Wrapf(err, "an error occurred with a message: \n%s\n and with fields: \n%s\n", message, fields)
 	sentry.Sentry().CaptureError(ctx, sentryError)
 
 	fields["err"] = err


### PR DESCRIPTION
There are two small improvements:

* in case of `NewUnauthorizedError` there was reported only the text `Could not resolve user token` without any additional information. I've attached the error that caused the failure to the message.

* in case of other errors than the internal ones, there was reported `error.stringError` instance. I've replaced it by wrapping the created message into the original error