### PR TITLE
Do not start jenkins on changes to DC

### DIFF
--- a/environment/templates/fabric8-tenant-jenkins.yml
+++ b/environment/templates/fabric8-tenant-jenkins.yml
@@ -789,8 +789,6 @@ objects:
         - configMap:
             name: jenkins
           name: jenkins-config
-    triggers:
-    - type: ConfigChange
 - apiVersion: v1
   kind: Route
   metadata:


### PR DESCRIPTION
This patch removes auto starting jenkins when there is a DC change as
it causes:

1. thundering-herd issue when we start all jenkins at once for a tenant
   update
2. Unnecessary wakes up jenkins that is sleeping
3. Restarts jenkins even if a build could be in progress

Issues: openshiftio/openshift.io#4306