### PR TITLE
chore: move whoami logic to cluster

### DIFF
--- a/cluster/service.go
+++ b/cluster/service.go
@@ -6,7 +6,6 @@ import (
 	"github.com/fabric8-services/fabric8-common/log"
 	"github.com/fabric8-services/fabric8-tenant/auth"
 	authclient "github.com/fabric8-services/fabric8-tenant/auth/client"
-	"github.com/fabric8-services/fabric8-tenant/openshift"
 	"github.com/pkg/errors"
 	"io/ioutil"
 	"strings"
@@ -154,7 +153,7 @@ func (s *clusterService) refreshCache(ctx context.Context) error {
 			return errors.Wrapf(err, "Unable to resolve token for cluster %v", cluster.APIURL)
 		}
 		// verify the token
-		_, err = openshift.WhoAmI(ctx, cluster.APIURL, clusterToken, s.authService.ClientOptions...)
+		_, err = WhoAmI(ctx, cluster.APIURL, clusterToken, s.authService.ClientOptions...)
 		if err != nil {
 			return errors.Wrapf(err, "token retrieved for cluster %v is invalid", cluster.APIURL)
 		}

--- a/cluster/whoami.go
+++ b/cluster/whoami.go
@@ -1,4 +1,4 @@
-package openshift
+package cluster
 
 import (
 	"bytes"

--- a/cluster/whoami_test.go
+++ b/cluster/whoami_test.go
@@ -1,15 +1,15 @@
-package openshift_test
+package cluster_test
 
 import (
 	"context"
 	"testing"
 
 	"github.com/fabric8-services/fabric8-tenant/configuration"
-	"github.com/fabric8-services/fabric8-tenant/openshift"
 	testsupport "github.com/fabric8-services/fabric8-tenant/test"
 	"github.com/fabric8-services/fabric8-tenant/test/recorder"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/fabric8-services/fabric8-tenant/cluster"
 )
 
 func TestWhoAmI(t *testing.T) {
@@ -24,7 +24,7 @@ func TestWhoAmI(t *testing.T) {
 
 	t.Run("ok", func(t *testing.T) {
 		// when
-		username, err := openshift.WhoAmI(context.Background(), "https://openshift.test", tok.Raw, configuration.WithRoundTripper(r))
+		username, err := cluster.WhoAmI(context.Background(), "https://openshift.test", tok.Raw, configuration.WithRoundTripper(r))
 		// then
 		require.NoError(t, err)
 		assert.Equal(t, "user_foo", username)
@@ -32,7 +32,7 @@ func TestWhoAmI(t *testing.T) {
 
 	t.Run("forbidden", func(t *testing.T) {
 		// when
-		username, err := openshift.WhoAmI(context.Background(), "https://openshift.test", "", configuration.WithRoundTripper(r))
+		username, err := cluster.WhoAmI(context.Background(), "https://openshift.test", "", configuration.WithRoundTripper(r))
 		// then
 		require.Error(t, err)
 		assert.Equal(t, "", username)

--- a/cluster/whoami_test.go
+++ b/cluster/whoami_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/fabric8-services/fabric8-tenant/cluster"
 	"github.com/fabric8-services/fabric8-tenant/configuration"
 	testsupport "github.com/fabric8-services/fabric8-tenant/test"
 	"github.com/fabric8-services/fabric8-tenant/test/recorder"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/fabric8-services/fabric8-tenant/cluster"
 )
 
 func TestWhoAmI(t *testing.T) {


### PR DESCRIPTION
This PR moves the "whoami" logic to `cluster` package. There are two reasons:

* the logic is used only there
* avoid cyclic package dependency in future