### PR TITLE
chore: use TenantToken to get info from JWT token & store ID in user

### DIFF
--- a/auth/service_test.go
+++ b/auth/service_test.go
@@ -116,22 +116,26 @@ func TestUserProfileClient_GetUserCluster(t *testing.T) {
 	tests := []struct {
 		name    string
 		user    string
+		uuid    string
 		wantErr string
 	}{
 		{
 			name:    "normal input to see if cluster is parsed",
 			wantErr: "",
 			user:    "normal_user",
+			uuid:    "4450a269-492e-45ec-939a-7766a4ee82de",
 		},
 		{
 			name:    "bad status code",
 			wantErr: "Not Found error: 404 not_found",
 			user:    "bad_status_code_user",
+			uuid:    "e4b8f368-bc45-4aa7-95d1-6a90dbbc8873",
 		},
 		{
 			name:    "make code fail on parsing output",
 			wantErr: "invalid character",
 			user:    "wrong_output_user",
+			uuid:    "7c094c6e-b62e-4f83-a9a3-695a048bb845",
 		},
 	}
 
@@ -151,11 +155,11 @@ func TestUserProfileClient_GetUserCluster(t *testing.T) {
 			// given
 			userToken, err := testsupport.NewToken(
 				map[string]interface{}{
-					"sub": testData.user,
+					"sub": testData.uuid,
 				},
 				"../test/private_key.pem",
 			)
-			require.NoError(t, err)
+			require.NoError(t, err, testData.user)
 
 			// when
 			user, err := authClientService.GetUser(goajwt.WithJWT(context.Background(), userToken))
@@ -167,9 +171,9 @@ func TestUserProfileClient_GetUserCluster(t *testing.T) {
 					testsupport.HasMessageContaining(testData.wantErr))
 				return
 			}
-			require.NoError(t, err)
-			require.NotNil(t, user)
-			assert.Equal(t, "fake-cluster.com", *user.UserData.Cluster)
+			require.NoError(t, err, testData.user)
+			require.NotNil(t, user, testData.user)
+			assert.Equal(t, "fake-cluster.com", *user.UserData.Cluster, testData.user)
 		})
 	}
 }

--- a/controller/tenant.go
+++ b/controller/tenant.go
@@ -88,7 +88,7 @@ func (c *TenantController) Setup(ctx *app.SetupTenantContext) error {
 	tenant := &tenant.Tenant{
 		ID:         ttoken.Subject(),
 		Email:      ttoken.Email(),
-		OSUsername: user.OpenshiftUsername,
+		OSUsername: user.OpenShiftUsername,
 	}
 	err = c.tenantService.CreateTenant(tenant)
 	if err != nil {
@@ -104,13 +104,13 @@ func (c *TenantController) Setup(ctx *app.SetupTenantContext) error {
 		err = openshift.RawInitTenant(
 			ctx,
 			openshiftConfig,
-			InitTenant(ctx, openshiftConfig.MasterURL, c.tenantService, t, user.OpenshiftUsername),
-			user.OpenshiftUsername,
-			user.OpenshiftUserToken)
+			InitTenant(ctx, openshiftConfig.MasterURL, c.tenantService, t, user.OpenShiftUsername),
+			user.OpenShiftUsername,
+			user.OpenShiftUserToken)
 
 		if err != nil {
 			sentry.LogError(ctx, map[string]interface{}{
-				"os_user": user.OpenshiftUsername,
+				"os_user": user.OpenShiftUsername,
 			}, err, "unable initialize tenant")
 		}
 	}()
@@ -155,7 +155,7 @@ func (c *TenantController) Update(ctx *app.UpdateTenantContext) error {
 	openshiftConfig := openshift.NewConfig(c.config, user.UserData, cluster.User, cluster.Token, cluster.APIURL)
 
 	// update tenant config
-	tenant.OSUsername = user.OpenshiftUsername
+	tenant.OSUsername = user.OpenShiftUsername
 
 	if err = c.tenantService.SaveTenant(tenant); err != nil {
 		log.Error(ctx, map[string]interface{}{
@@ -170,12 +170,12 @@ func (c *TenantController) Update(ctx *app.UpdateTenantContext) error {
 		err = openshift.RawUpdateTenant(
 			ctx,
 			openshiftConfig,
-			InitTenant(ctx, openshiftConfig.MasterURL, c.tenantService, t, user.OpenshiftUsername),
-			user.OpenshiftUsername)
+			InitTenant(ctx, openshiftConfig.MasterURL, c.tenantService, t, user.OpenShiftUsername),
+			user.OpenShiftUsername)
 
 		if err != nil {
 			sentry.LogError(ctx, map[string]interface{}{
-				"os_user": user.OpenshiftUsername,
+				"os_user": user.OpenShiftUsername,
 			}, err, "unable initialize tenant")
 		}
 	}()
@@ -216,7 +216,7 @@ func (c *TenantController) Clean(ctx *app.CleanTenantContext) error {
 	// create openshift config
 	openshiftConfig := openshift.NewConfig(c.config, user.UserData, cluster.User, cluster.Token, cluster.APIURL)
 
-	err = openshift.CleanTenant(ctx, openshiftConfig, user.OpenshiftUsername, removeFromCluster)
+	err = openshift.CleanTenant(ctx, openshiftConfig, user.OpenShiftUsername, removeFromCluster)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}

--- a/test/data/token/auth_resolve_user.yaml
+++ b/test/data/token/auth_resolve_user.yaml
@@ -3,7 +3,7 @@ version: 1
 interactions:
 - request:
     method: GET
-    url: http://authservice/api/users/normal_user
+    url: http://authservice/api/users/4450a269-492e-45ec-939a-7766a4ee82de
     headers:
       sub: ["tenant_service"] # will be compared against the `sub` claim in the incoming request's token
   response:
@@ -20,18 +20,18 @@ interactions:
     method: GET
     url: http://authservice/api/token?for=fake-cluster.com&force_pull=false
     headers:
-      sub: ["normal_user"] # will be compared against the `sub` claim in the incoming request's token
+      sub: ["4450a269-492e-45ec-939a-7766a4ee82de"] # will be compared against the `sub` claim in the incoming request's token
   response:
     status: 200 OK
     code: 200
-    body: '{ 
+    body: '{
 			"access_token": "an_openshift_token",
 			"token_type": "bearer",
 			"username": "user_foo"
 		}'
 - request:
     method: GET
-    url: http://authservice/api/users/bad_status_code_user
+    url: http://authservice/api/users/e4b8f368-bc45-4aa7-95d1-6a90dbbc8873
     headers:
       sub: ["tenant_service"] # will be compared against the `sub` claim in the incoming request's token
   response:
@@ -47,7 +47,7 @@ interactions:
         }'
 - request:
     method: GET
-    url: http://authservice/api/users/wrong_output_user
+    url: http://authservice/api/users/7c094c6e-b62e-4f83-a9a3-695a048bb845
     headers:
       sub: ["tenant_service"] # will be compared against the `sub` claim in the incoming request's token
   response:


### PR DESCRIPTION
Changes proposed in this PR:

* rename both `OpenshiftUsername` and `OpenShiftUserToken` to `OpenShiftUsername` and `OpenShiftUsername` with capital "S" in the word "OpenShift"
* Use `TenantToken` object to retreive info from the token
* Store Tenant ID in `User` object - will be used in cases when we need only the tenant ID so we don't have to fetch user information from auth
