### PR TITLE
chore: move test functions to separated files/packages

### DIFF
--- a/auth/service_test.go
+++ b/auth/service_test.go
@@ -54,7 +54,7 @@ func TestResolveUserToken(t *testing.T) {
 
 func TestResolveServiceAccountToken(t *testing.T) {
 	// given
-	reset := testdoubles.SetEnvironments(testdoubles.Env("F8_AUTH_TOKEN_KEY", "foo"))
+	reset := testsupport.SetEnvironments(testsupport.Env("F8_AUTH_TOKEN_KEY", "foo"))
 	defer reset()
 	authService, cleanup := testdoubles.NewAuthService(t, "../test/data/token/auth_resolve_target_token", "http://authservice", recorder.WithJWTMatcher)
 	defer cleanup()
@@ -201,7 +201,7 @@ func TestPublicKeys(t *testing.T) {
 
 func TestInitializeAuthServiceAndGetSaToken(t *testing.T) {
 	// given
-	reset := testdoubles.SetEnvironments(testdoubles.Env("F8_AUTH_URL", "http://authservice"))
+	reset := testsupport.SetEnvironments(testsupport.Env("F8_AUTH_URL", "http://authservice"))
 	defer reset()
 	record, err := recorder.New("../test/data/token/auth_resolve_target_token")
 	defer func() {

--- a/cluster/service_test.go
+++ b/cluster/service_test.go
@@ -18,7 +18,7 @@ import (
 func TestResolveCluster(t *testing.T) {
 
 	// given
-	reset := testdoubles.SetEnvironments(testdoubles.Env("F8_AUTH_TOKEN_KEY", "foo"))
+	reset := testsupport.SetEnvironments(testsupport.Env("F8_AUTH_TOKEN_KEY", "foo"))
 	defer reset()
 	authService, cleanup := testdoubles.NewAuthService(t, "../test/data/cluster/resolve_cluster.fast", "http://fast.authservice", recorder.WithJWTMatcher)
 	defer cleanup()
@@ -80,7 +80,7 @@ func TestResolveCluster(t *testing.T) {
 
 func TestGetClusters(t *testing.T) {
 	// given
-	reset := testdoubles.SetEnvironments(testdoubles.Env("F8_AUTH_TOKEN_KEY", "foo"))
+	reset := testsupport.SetEnvironments(testsupport.Env("F8_AUTH_TOKEN_KEY", "foo"))
 	defer reset()
 	authService, cleanup := testdoubles.NewAuthService(t, "../test/data/cluster/resolve_cluster.slow", "http://slow.authservice", recorder.WithJWTMatcher)
 	defer cleanup()

--- a/controller/tenants_test.go
+++ b/controller/tenants_test.go
@@ -283,7 +283,7 @@ func createInvalidSAContext() context.Context {
 }
 
 func (s *TenantsControllerTestSuite) newTestTenantsController(filename string) (*goa.Service, *controller.TenantsController, error) {
-	reset := testdoubles.SetEnvironments(testdoubles.Env("F8_AUTH_TOKEN_KEY", "foo"))
+	reset := testsupport.SetEnvironments(testsupport.Env("F8_AUTH_TOKEN_KEY", "foo"))
 	defer reset()
 	cassetteFile := fmt.Sprintf("../test/data/controller/%s", filename)
 	authService, r, cleanup := testdoubles.NewAuthServiceWithRecorder(s.T(), cassetteFile, "http://authservice", recorder.WithJWTMatcher)

--- a/environment/service_test.go
+++ b/environment/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/fabric8-services/fabric8-tenant/environment"
 	"github.com/fabric8-services/fabric8-tenant/tenant"
+	"github.com/fabric8-services/fabric8-tenant/test/doubles"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
@@ -55,7 +56,7 @@ items:
 func TestGetAllTemplatesForAllTypes(t *testing.T) {
 	// given
 	service := environment.NewService("", "", "")
-	setTemplateVersions()
+	testdoubles.SetTemplateVersions()
 	vars := map[string]string{
 		"USER_NAME": "dev",
 	}
@@ -105,7 +106,7 @@ func TestGetAllTemplatesForAllTypes(t *testing.T) {
 
 func TestAllTemplatesHaveNecessaryData(t *testing.T) {
 	// given
-	setTemplateVersions()
+	testdoubles.SetTemplateVersions()
 	service := environment.NewService("", "", "")
 	vars := map[string]string{
 		"USER_NAME": "dev",
@@ -135,20 +136,10 @@ func TestAllTemplatesHaveNecessaryData(t *testing.T) {
 	}
 }
 
-func setTemplateVersions() {
-	environment.VersionFabric8TenantCheFile = "123abc"
-	environment.VersionFabric8TenantCheMtFile = "234bcd"
-	environment.VersionFabric8TenantCheQuotasFile = "zyx098"
-	environment.VersionFabric8TenantUserFile = "345cde"
-	environment.VersionFabric8TenantDeployFile = "456def"
-	environment.VersionFabric8TenantJenkinsFile = "567efg"
-	environment.VersionFabric8TenantJenkinsQuotasFile = "yxw987"
-}
-
 // Ignored because it downloads files directly from GitHub
 func XTestDownloadFromExistingLocation(t *testing.T) {
 	// given
-	setTemplateVersions()
+	testdoubles.SetTemplateVersions()
 	service := environment.NewService("", "29541ca", "")
 	vars := map[string]string{
 		"USER_NAME": "dev",
@@ -178,7 +169,7 @@ func TestDownloadFromGivenBlob(t *testing.T) {
 		Get("fabric8-services/fabric8-tenant/987654321/environment/templates/fabric8-tenant-deploy.yml").
 		Reply(200).
 		BodyString(defaultLocationTempl)
-	setTemplateVersions()
+	testdoubles.SetTemplateVersions()
 	service := environment.NewService("", "987654321", "")
 
 	// when
@@ -207,7 +198,7 @@ func TestDownloadFromGivenBlobLocatedInCustomLocation(t *testing.T) {
 		Get("my-services/my-tenant/987cba/any/path/fabric8-tenant-jenkins-quotas.yml").
 		Reply(200).
 		BodyString(customLocationQuotas)
-	setTemplateVersions()
+	testdoubles.SetTemplateVersions()
 	service := environment.NewService("http://github.com/my-services/my-tenant", "987cba", "any/path")
 
 	// when

--- a/environment/template_test.go
+++ b/environment/template_test.go
@@ -2,7 +2,7 @@ package environment_test
 
 import (
 	"github.com/fabric8-services/fabric8-tenant/environment"
-	"github.com/fabric8-services/fabric8-tenant/test/doubles"
+	"github.com/fabric8-services/fabric8-tenant/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"regexp"
@@ -154,7 +154,7 @@ parameters:
 
 func TestSort(t *testing.T) {
 	// given
-	data, reset := testdoubles.LoadTestConfig(t)
+	data, reset := test.LoadTestConfig(t)
 	defer reset()
 
 	template := environment.Template{Content: sortTemplate}
@@ -174,7 +174,7 @@ func TestSort(t *testing.T) {
 
 func TestParseNamespace(t *testing.T) {
 	// given
-	data, reset := testdoubles.LoadTestConfig(t)
+	data, reset := test.LoadTestConfig(t)
 	defer reset()
 
 	template := environment.Template{Content: parseNamespaceTemplate}

--- a/openshift/apply_test.go
+++ b/openshift/apply_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/fabric8-services/fabric8-tenant/configuration"
 	"github.com/fabric8-services/fabric8-tenant/environment"
 	"github.com/fabric8-services/fabric8-tenant/openshift"
-	"github.com/fabric8-services/fabric8-tenant/test/doubles"
+	"github.com/fabric8-services/fabric8-tenant/test"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
 	"os"
@@ -65,7 +65,7 @@ func TestMain(m *testing.M) {
 
 func TestInvokePostAndGetCallsForAllObjects(t *testing.T) {
 	// given
-	config, reset := testdoubles.LoadTestConfig(t)
+	config, reset := test.LoadTestConfig(t)
 	defer reset()
 	objects, opts := prepareObjectsAndOpts(t, templateHeader+projectRequestObject+roleBindingRestrictionObject, config)
 
@@ -91,7 +91,7 @@ func TestInvokePostAndGetCallsForAllObjects(t *testing.T) {
 
 func TestDeleteIfThereIsConflict(t *testing.T) {
 	// given
-	config, reset := testdoubles.LoadTestConfig(t)
+	config, reset := test.LoadTestConfig(t)
 	defer reset()
 	objects, opts := prepareObjectsAndOpts(t, templateHeader+roleBindingRestrictionObject, config)
 
@@ -120,7 +120,7 @@ func TestDeleteIfThereIsConflict(t *testing.T) {
 
 func TestDeleteAndGet(t *testing.T) {
 	// given
-	config, reset := testdoubles.LoadTestConfig(t)
+	config, reset := test.LoadTestConfig(t)
 	defer reset()
 	objects, opts := prepareObjectsAndOpts(t, templateHeader+roleBindingRestrictionObject, config)
 

--- a/openshift/init_tenant_test.go
+++ b/openshift/init_tenant_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"github.com/fabric8-services/fabric8-tenant/auth/client"
 	"github.com/fabric8-services/fabric8-tenant/openshift"
-	"github.com/fabric8-services/fabric8-tenant/test/doubles"
+	"github.com/fabric8-services/fabric8-tenant/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
@@ -18,7 +18,7 @@ var emptyCallback = func(statusCode int, method string, request, response map[in
 
 func TestNumberOfCallsToCluster(t *testing.T) {
 	// given
-	data, reset := testdoubles.LoadTestConfig(t)
+	data, reset := test.LoadTestConfig(t)
 	defer func() {
 		gock.OffAll()
 		reset()

--- a/openshift/process_template_test.go
+++ b/openshift/process_template_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/fabric8-services/fabric8-tenant/configuration"
 	"github.com/fabric8-services/fabric8-tenant/environment"
 	"github.com/fabric8-services/fabric8-tenant/openshift"
-	"github.com/fabric8-services/fabric8-tenant/test/doubles"
+	"github.com/fabric8-services/fabric8-tenant/test"
 	"github.com/stretchr/testify/assert"
 	"strings"
 )
 
 func TestPresenceOfTemplateObjects(t *testing.T) {
-	data, reset := testdoubles.LoadTestConfig(t)
+	data, reset := test.LoadTestConfig(t)
 	defer reset()
 	templateObjects := tmplObjects(t, data)
 
@@ -80,9 +80,9 @@ func TestPresenceOfTemplateObjects(t *testing.T) {
 	})
 
 	t.Run("verify resource quotas are not present when DISABLE_OSO_QUOTAS is true", func(t *testing.T) {
-		resetEnv := testdoubles.SetEnvironments(testdoubles.Env("DISABLE_OSO_QUOTAS", "true"))
+		resetEnv := test.SetEnvironments(test.Env("DISABLE_OSO_QUOTAS", "true"))
 		defer resetEnv()
-		data, reset := testdoubles.LoadTestConfig(t)
+		data, reset := test.LoadTestConfig(t)
 		defer reset()
 		templateObjects := tmplObjects(t, data)
 

--- a/sentry/sentry_test.go
+++ b/sentry/sentry_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/dgrijalva/jwt-go"
 	"github.com/fabric8-services/fabric8-common/sentry"
 	"github.com/fabric8-services/fabric8-tenant/configuration"
-	"github.com/fabric8-services/fabric8-tenant/test/doubles"
+	"github.com/fabric8-services/fabric8-tenant/test"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
@@ -16,7 +16,7 @@ import (
 
 func TestInitializeSentryLoggerAndSendRecord(t *testing.T) {
 	// given
-	reset := testdoubles.SetEnvironments(testdoubles.Env("F8_SENTRY_DSN", "https://abcdef123:abcde123@sentry.instance.server.io/1"))
+	reset := test.SetEnvironments(test.Env("F8_SENTRY_DSN", "https://abcdef123:abcde123@sentry.instance.server.io/1"))
 	defer reset()
 	config, err := configuration.NewData()
 	require.NoError(t, err)

--- a/test/config.go
+++ b/test/config.go
@@ -1,0 +1,40 @@
+package test
+
+import (
+	"github.com/fabric8-services/fabric8-tenant/configuration"
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+func LoadTestConfig(t *testing.T) (*configuration.Data, func()) {
+	reset := SetEnvironments(
+		Env("F8_TEMPLATE_RECOMMENDER_EXTERNAL_NAME", "recommender.api.prod-preview.openshift.io"),
+		Env("F8_TEMPLATE_RECOMMENDER_API_TOKEN", "xxxx"),
+		Env("F8_TEMPLATE_DOMAIN", "d800.free-int.openshiftapps.com"))
+	data, err := configuration.GetData()
+	require.NoError(t, err)
+	return data, reset
+}
+
+func Env(key, value string) Environment {
+	return Environment{key: key, value: value}
+}
+
+type Environment struct {
+	key, value string
+}
+
+func SetEnvironments(environments ...Environment) func() {
+	originalValues := make([]Environment, 0, len(environments))
+
+	for _, env := range environments {
+		originalValues = append(originalValues, Env(env.key, os.Getenv(env.key)))
+		os.Setenv(env.key, env.value)
+	}
+	return func() {
+		for _, env := range originalValues {
+			os.Setenv(env.key, env.value)
+		}
+	}
+}


### PR DESCRIPTION
This PR moves:

* all test functions related to configuration and environments to `test` package (to `config.go` file)
* `setTemplateVersions` function to `testdoubles` package

the reason is to avoid cyclic package dependency in the future and to allow using `setTemplateVersions` in more tests/packages