### PR TITLE
fix(#674): introduce nsUsername used as base-name for namespace names

### DIFF
--- a/controller/tenant.go
+++ b/controller/tenant.go
@@ -83,7 +83,14 @@ func (c *TenantController) Setup(ctx *app.SetupTenantContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, err))
 	}
 
-	username := tenant.ConstructNsUsername(c.tenantService, env.RetrieveUserName(user.OpenShiftUsername))
+	username, err := tenant.ConstructNsUsername(c.tenantService, env.RetrieveUserName(user.OpenShiftUsername))
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"err":         err,
+			"os_username": user.OpenShiftUsername,
+		}, "unable to construct namespace base name")
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, err))
+	}
 
 	// create openshift config
 	openshiftConfig := openshift.NewConfig(c.config, user.UserData, cluster.User, cluster.Token, cluster.APIURL)

--- a/environment/template.go
+++ b/environment/template.go
@@ -152,11 +152,11 @@ func (t *Template) ReplaceVars(variables map[string]string) (string, error) {
 	})), nil
 }
 
-func CollectVars(user, username, masterUser string, config *configuration.Data) map[string]string {
+func CollectVars(osUsername, nsBaseName, masterUser string, config *configuration.Data) map[string]string {
 	vars := map[string]string{
-		varUserName:              username,
-		varProjectUser:           user,
-		varProjectRequestingUser: user,
+		varUserName:              nsBaseName,
+		varProjectUser:           osUsername,
+		varProjectRequestingUser: osUsername,
 		varProjectAdminUser:      masterUser,
 	}
 

--- a/environment/template.go
+++ b/environment/template.go
@@ -152,11 +152,9 @@ func (t *Template) ReplaceVars(variables map[string]string) (string, error) {
 	})), nil
 }
 
-func CollectVars(user, masterUser string, config *configuration.Data) map[string]string {
-	userName := RetrieveUserName(user)
-
+func CollectVars(user, username, masterUser string, config *configuration.Data) map[string]string {
 	vars := map[string]string{
-		varUserName:              userName,
+		varUserName:              username,
 		varProjectUser:           user,
 		varProjectRequestingUser: user,
 		varProjectAdminUser:      masterUser,

--- a/environment/template_test.go
+++ b/environment/template_test.go
@@ -158,7 +158,7 @@ func TestSort(t *testing.T) {
 	defer reset()
 
 	template := environment.Template{Content: sortTemplate}
-	objects, err := template.Process(environment.CollectVars("developer", "master", data))
+	objects, err := template.Process(environment.CollectVars("developer", "developer", "master", data))
 
 	// when
 	sort.Sort(environment.ByKind(objects))
@@ -180,7 +180,7 @@ func TestParseNamespace(t *testing.T) {
 	template := environment.Template{Content: parseNamespaceTemplate}
 
 	// when
-	objects, err := template.Process(environment.CollectVars("developer", "master", data))
+	objects, err := template.Process(environment.CollectVars("developer", "developer", "master", data))
 
 	// then
 	require.NoError(t, err)

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -106,6 +106,7 @@ func getMigrations() migrations {
 	m = append(m, steps{executeSQLFile("003-profiles.sql")})
 	m = append(m, steps{executeSQLFile("004-index-tenants-search.sql")})
 	m = append(m, steps{executeSQLFile("005-add-username-column-to-tenant.sql")})
+	m = append(m, steps{executeSQLFile("006-add-ns-username-column-to-tenant.sql")})
 
 	// Version N
 	//

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -106,7 +106,7 @@ func getMigrations() migrations {
 	m = append(m, steps{executeSQLFile("003-profiles.sql")})
 	m = append(m, steps{executeSQLFile("004-index-tenants-search.sql")})
 	m = append(m, steps{executeSQLFile("005-add-username-column-to-tenant.sql")})
-	m = append(m, steps{executeSQLFile("006-add-ns-username-column-to-tenant.sql")})
+	m = append(m, steps{executeSQLFile("006-add-ns-base-name-column-to-tenant.sql")})
 
 	// Version N
 	//

--- a/migration/sql-files/006-add-ns-base-name-column-to-tenant.sql
+++ b/migration/sql-files/006-add-ns-base-name-column-to-tenant.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tenants ADD COLUMN ns_base_name TEXT;
+CREATE INDEX idx_ns_base_name ON tenants USING btree (ns_base_name);
+UPDATE tenants SET ns_base_name = (SELECT name FROM namespaces n WHERE tenants.id = n.tenant_id AND n.type = 'user');

--- a/migration/sql-files/006-add-ns-username-column-to-tenant.sql
+++ b/migration/sql-files/006-add-ns-username-column-to-tenant.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tenants
+ADD COLUMN ns_username TEXT;

--- a/migration/sql-files/006-add-ns-username-column-to-tenant.sql
+++ b/migration/sql-files/006-add-ns-username-column-to-tenant.sql
@@ -1,2 +1,2 @@
-ALTER TABLE tenants
-ADD COLUMN ns_username TEXT;
+ALTER TABLE tenants ADD COLUMN ns_username TEXT;
+CREATE INDEX idx_ns_username ON tenants USING btree (ns_username);

--- a/migration/sql-files/006-add-ns-username-column-to-tenant.sql
+++ b/migration/sql-files/006-add-ns-username-column-to-tenant.sql
@@ -1,3 +1,0 @@
-ALTER TABLE tenants ADD COLUMN ns_username TEXT;
-CREATE INDEX idx_ns_username ON tenants USING btree (ns_username);
-UPDATE tenants t SET t.ns_username = (SELECT name FROM namespaces n WHERE t.id = n.tenant_id AND t.type = 'user');

--- a/migration/sql-files/006-add-ns-username-column-to-tenant.sql
+++ b/migration/sql-files/006-add-ns-username-column-to-tenant.sql
@@ -1,2 +1,3 @@
 ALTER TABLE tenants ADD COLUMN ns_username TEXT;
 CREATE INDEX idx_ns_username ON tenants USING btree (ns_username);
+UPDATE tenants t SET t.ns_username = (SELECT name FROM namespaces n WHERE t.id = n.tenant_id AND t.type = 'user');

--- a/openshift/apply_test.go
+++ b/openshift/apply_test.go
@@ -140,7 +140,7 @@ func TestDeleteAndGet(t *testing.T) {
 
 func prepareObjectsAndOpts(t *testing.T, content string, config *configuration.Data) (environment.Objects, openshift.ApplyOptions) {
 	template := environment.Template{Content: content}
-	objects, err := template.Process(environment.CollectVars("aslak", "master", config))
+	objects, err := template.Process(environment.CollectVars("aslak", "aslak", "master", config))
 	require.NoError(t, err)
 	opts := openshift.ApplyOptions{
 		Config: openshift.Config{

--- a/openshift/clean_tenant.go
+++ b/openshift/clean_tenant.go
@@ -10,8 +10,8 @@ import (
 )
 
 // CleanTenant clean or remove
-func CleanTenant(ctx context.Context, config Config, username string, remove bool) error {
-	templs, err := LoadProcessedTemplates(ctx, config, username)
+func CleanTenant(ctx context.Context, config Config, osUsername, username string, remove bool) error {
+	templs, err := LoadProcessedTemplates(ctx, config, osUsername, username)
 	if err != nil {
 		return err
 	}

--- a/openshift/clean_tenant.go
+++ b/openshift/clean_tenant.go
@@ -10,8 +10,8 @@ import (
 )
 
 // CleanTenant clean or remove
-func CleanTenant(ctx context.Context, config Config, osUsername, username string, remove bool) error {
-	templs, err := LoadProcessedTemplates(ctx, config, osUsername, username)
+func CleanTenant(ctx context.Context, config Config, osUsername, nsBaseName string, remove bool) error {
+	templs, err := LoadProcessedTemplates(ctx, config, osUsername, nsBaseName)
 	if err != nil {
 		return err
 	}

--- a/openshift/init_tenant.go
+++ b/openshift/init_tenant.go
@@ -12,8 +12,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func RawInitTenant(ctx context.Context, config Config, callback Callback, openshiftUsername, usertoken string) error {
-	templs, err := LoadProcessedTemplates(ctx, config, openshiftUsername)
+func RawInitTenant(ctx context.Context, config Config, callback Callback, openshiftUsername, username, usertoken string) error {
+	templs, err := LoadProcessedTemplates(ctx, config, openshiftUsername, username)
 	if err != nil {
 		return err
 	}
@@ -26,7 +26,6 @@ func RawInitTenant(ctx context.Context, config Config, callback Callback, opensh
 	userOpts := ApplyOptions{Config: config.WithToken(usertoken), Callback: callback}
 	var wg sync.WaitGroup
 	wg.Add(len(mapped))
-	username := env.RetrieveUserName(openshiftUsername)
 	for key, val := range mapped {
 		namespaceType := tenant.GetNamespaceType(key, username)
 		if namespaceType == tenant.TypeUser {
@@ -88,8 +87,8 @@ func RawInitTenant(ctx context.Context, config Config, callback Callback, opensh
 	return nil
 }
 
-func RawUpdateTenant(ctx context.Context, config Config, callback Callback, username string) error {
-	templs, err := LoadProcessedTemplates(ctx, config, username)
+func RawUpdateTenant(ctx context.Context, config Config, callback Callback, osUsername, username string) error {
+	templs, err := LoadProcessedTemplates(ctx, config, osUsername, username)
 	if err != nil {
 		return err
 	}

--- a/openshift/init_tenant.go
+++ b/openshift/init_tenant.go
@@ -12,8 +12,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func RawInitTenant(ctx context.Context, config Config, callback Callback, openshiftUsername, username, usertoken string) error {
-	templs, err := LoadProcessedTemplates(ctx, config, openshiftUsername, username)
+func RawInitTenant(ctx context.Context, config Config, callback Callback, openshiftUsername, nsBaseName, usertoken string) error {
+	templs, err := LoadProcessedTemplates(ctx, config, openshiftUsername, nsBaseName)
 	if err != nil {
 		return err
 	}
@@ -27,7 +27,7 @@ func RawInitTenant(ctx context.Context, config Config, callback Callback, opensh
 	var wg sync.WaitGroup
 	wg.Add(len(mapped))
 	for key, val := range mapped {
-		namespaceType := tenant.GetNamespaceType(key, username)
+		namespaceType := tenant.GetNamespaceType(key, nsBaseName)
 		if namespaceType == tenant.TypeUser {
 			go func(namespace string, objects env.Objects, opts, userOpts ApplyOptions) {
 				defer wg.Done()
@@ -87,8 +87,8 @@ func RawInitTenant(ctx context.Context, config Config, callback Callback, opensh
 	return nil
 }
 
-func RawUpdateTenant(ctx context.Context, config Config, callback Callback, osUsername, username string) error {
-	templs, err := LoadProcessedTemplates(ctx, config, osUsername, username)
+func RawUpdateTenant(ctx context.Context, config Config, callback Callback, osUsername, nsBaseName string) error {
+	templs, err := LoadProcessedTemplates(ctx, config, osUsername, nsBaseName)
 	if err != nil {
 		return err
 	}

--- a/openshift/init_tenant_test.go
+++ b/openshift/init_tenant_test.go
@@ -37,7 +37,7 @@ func TestNumberOfCallsToCluster(t *testing.T) {
 	objectsInTemplates := tmplObjects(t, data)
 
 	// when
-	err := openshift.RawInitTenant(context.Background(), config, emptyCallback, "developer", "12345")
+	err := openshift.RawInitTenant(context.Background(), config, emptyCallback, "developer", "developer", "12345")
 
 	// then
 	require.NoError(t, err)

--- a/openshift/process_template.go
+++ b/openshift/process_template.go
@@ -43,10 +43,10 @@ func IsNotOfKind(kinds ...string) FilterFunc {
 	}
 }
 
-func LoadProcessedTemplates(ctx context.Context, config Config, username string) (environment.Objects, error) {
+func LoadProcessedTemplates(ctx context.Context, config Config, osUsername, username string) (environment.Objects, error) {
 
 	envService := environment.NewService(config.TemplatesRepo, config.TemplatesRepoBlob, config.TemplatesRepoDir)
-	vars := environment.CollectVars(username, config.MasterUser, config.OriginalConfig)
+	vars := environment.CollectVars(osUsername, username, config.MasterUser, config.OriginalConfig)
 	var objs environment.Objects
 
 	for _, envType := range environment.DefaultEnvTypes {

--- a/openshift/process_template.go
+++ b/openshift/process_template.go
@@ -43,10 +43,10 @@ func IsNotOfKind(kinds ...string) FilterFunc {
 	}
 }
 
-func LoadProcessedTemplates(ctx context.Context, config Config, osUsername, username string) (environment.Objects, error) {
+func LoadProcessedTemplates(ctx context.Context, config Config, osUsername, nsBaseName string) (environment.Objects, error) {
 
 	envService := environment.NewService(config.TemplatesRepo, config.TemplatesRepoBlob, config.TemplatesRepoDir)
-	vars := environment.CollectVars(osUsername, username, config.MasterUser, config.OriginalConfig)
+	vars := environment.CollectVars(osUsername, nsBaseName, config.MasterUser, config.OriginalConfig)
 	var objs environment.Objects
 
 	for _, envType := range environment.DefaultEnvTypes {

--- a/openshift/process_template_test.go
+++ b/openshift/process_template_test.go
@@ -104,7 +104,7 @@ func TestPresenceOfTemplateObjects(t *testing.T) {
 
 func tmplObjects(t *testing.T, data *configuration.Data) environment.Objects {
 	config := openshift.Config{OriginalConfig: data, MasterUser: "master"}
-	templs, err := openshift.LoadProcessedTemplates(context.Background(), config, "developer")
+	templs, err := openshift.LoadProcessedTemplates(context.Background(), config, "developer", "developer")
 	assert.NoError(t, err)
 	return templs
 }

--- a/tenant/tenant.go
+++ b/tenant/tenant.go
@@ -55,7 +55,7 @@ type Tenant struct {
 	Email      string
 	Profile    string
 	OSUsername string
-	NsUsername string
+	NsBaseName string
 }
 
 // TableName overrides the table name settings in Gorm to force a specific table name
@@ -85,8 +85,8 @@ func (m Namespace) TableName() string {
 }
 
 // GetNamespaceType attempts to extract the namespace type based on namespace name
-func GetNamespaceType(name, username string) NamespaceType {
-	if name == username {
+func GetNamespaceType(name, nsBaseName string) NamespaceType {
+	if name == nsBaseName {
 		return TypeUser
 	}
 	if strings.HasSuffix(name, "-jenkins") {

--- a/tenant/tenant.go
+++ b/tenant/tenant.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/satori/go.uuid"
 )
 
 // NamespaceType describes which type of namespace this is
@@ -55,6 +55,7 @@ type Tenant struct {
 	Email      string
 	Profile    string
 	OSUsername string
+	NsUsername string
 }
 
 // TableName overrides the table name settings in Gorm to force a specific table name


### PR DESCRIPTION
This PR introduces `nsUsername` in `tenant` table. It is used as a base-name (eg. `johny`) for namespace names. When a new tenant is being created, then it checks if there is some tenant or namespace that the same base-name already uses. If there is some, then it appends a number to the name starting with number 2 (eg. `johny2`) and checks for any conflict again.