### PR TITLE
fix(#688): add error msg when token retrieval failed

### DIFF
--- a/auth/service_test.go
+++ b/auth/service_test.go
@@ -50,6 +50,17 @@ func TestResolveUserToken(t *testing.T) {
 		// then
 		testsupport.AssertError(t, err, testsupport.HasMessage("token must not be empty"))
 	})
+
+	t.Run("token is missing", func(t *testing.T) {
+		// when
+		_, _, err := authService.ResolveUserToken(context.Background(), "missing_token_resource", tok.Raw)
+		// then
+		testsupport.AssertError(t, err,
+			testsupport.HasMessageContaining(
+				"LINK url=https://auth.openshift.io/api/token/link?for=https://github.com, description=\"GitHub token is missing. Link GitHub account\""),
+			testsupport.HasMessageContaining("occurred an error with message"),
+			testsupport.HasMessageContaining("token is missing"))
+	})
 }
 
 func TestResolveServiceAccountToken(t *testing.T) {

--- a/test/data/token/auth_resolve_target_token.yaml
+++ b/test/data/token/auth_resolve_target_token.yaml
@@ -49,6 +49,26 @@ interactions:
     }'
 - request:
     method: GET
+    url: http://authservice/api/token?for=missing_token_resource&force_pull=false
+    headers:
+      sub: ["user_foo"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 401 Unauthorized
+    code: 401
+    headers:
+      WWW-Authenticate: ["LINK url=https://auth.openshift.io/api/token/link?for=https://github.com, description=\"GitHub token is missing. Link GitHub account\""]
+    body: '{
+      "errors":[
+        { "code":"unauthorized_error",
+          "detail":"token is missing",
+          "id":"t/DyvMrf",
+          "status":"401",
+          "title":"Unauthorized error"
+        }
+      ]
+    }'
+- request:
+    method: GET
     url: http://authservice/api/token?for=some_valid_openshift_resource_for_service&force_pull=false
     headers:
       sub: ["tenant_service"] # will be compared against the `sub` claim in the incoming request's token


### PR DESCRIPTION
When token retrieval fails, then add also error message from header to the resulting error

Fix: #688 