### PR TITLE
fix(#693): print whole respone from auth when error occurs

### DIFF
--- a/test/data/token/auth_resolve_target_token.yaml
+++ b/test/data/token/auth_resolve_target_token.yaml
@@ -33,10 +33,12 @@ interactions:
     }'
 - request:
     method: GET
-    url: http://authservice/api/token?for=some_valid_openshift_resource&force_pull=false
+    url: http://authservice/api/token?for=missing_header_resource&force_pull=false
   response:
     status: 401 Unauthorized
     code: 401
+    headers:
+      error-message: ["error message in header"]
     body: '{
       "errors":[
         { "code":"jwt_security_error",
@@ -82,7 +84,7 @@ interactions:
 		}'
 - request:
     method: GET
-    url: http://authservice/api/token?for=some_invalid_resource&force_pull=true
+    url: http://authservice/api/token?for=some_invalid_resource&force_pull=false
     headers:
       sub: ["tenant_service"] # will be compared against the `sub` claim in the incoming request's token
   response:
@@ -99,7 +101,7 @@ interactions:
     }'
 - request:
     method: GET
-    url: http://authservice/api/token?for=some_valid_openshift_resource&force_pull=true
+    url: http://authservice/api/token?for=some_valid_openshift_resource&force_pull=false
   response:
     status: 401 Unauthorized
     code: 401
@@ -115,7 +117,7 @@ interactions:
     }'
 - request:
     method: GET
-    url: http://authservice/api/token?for=some_valid_openshift_resource&force_pull=true
+    url: http://authservice/api/token?for=some_valid_openshift_resource&force_pull=false
     headers:
       sub: ["expired_tenant_service"] # will be compared against the `sub` claim in the incoming request's token
   response:


### PR DESCRIPTION
when an error occurs and the header `WWW-Authenticate` is not found, then it prints the whole content of the response.
This PR also fixes some of the mocked request-response communication