### PR TITLE
create environment.Type and use it instead of NamespaceType

### DIFF
--- a/controller/tenant.go
+++ b/controller/tenant.go
@@ -184,7 +184,7 @@ func (c *TenantController) Update(ctx *app.UpdateTenantContext) error {
 	return ctx.Accepted()
 }
 
-func UpdateTenantWithErrorHandling(updateExecutor UpdateExecutor, ctx context.Context, tenantService tenant.Service, openshiftConfig openshift.Config, t *tenant.Tenant, envTypes ...string) {
+func UpdateTenantWithErrorHandling(updateExecutor UpdateExecutor, ctx context.Context, tenantService tenant.Service, openshiftConfig openshift.Config, t *tenant.Tenant, envTypes ...env.Type) {
 	err := UpdateTenant(updateExecutor, ctx, tenantService, openshiftConfig, t, envTypes...)
 	if err != nil {
 		sentry.LogError(ctx, map[string]interface{}{
@@ -195,7 +195,7 @@ func UpdateTenantWithErrorHandling(updateExecutor UpdateExecutor, ctx context.Co
 	}
 }
 
-func UpdateTenant(updateExecutor UpdateExecutor, ctx context.Context, tenantService tenant.Service, openshiftConfig openshift.Config, t *tenant.Tenant, envTypes ...string) error {
+func UpdateTenant(updateExecutor UpdateExecutor, ctx context.Context, tenantService tenant.Service, openshiftConfig openshift.Config, t *tenant.Tenant, envTypes ...env.Type) error {
 	versionMapping, err := updateExecutor.Update(ctx, tenantService, openshiftConfig, t, envTypes)
 	if err != nil {
 		updateNamespaceEntities(tenantService, t, versionMapping, true)
@@ -205,7 +205,7 @@ func UpdateTenant(updateExecutor UpdateExecutor, ctx context.Context, tenantServ
 	return updateNamespaceEntities(tenantService, t, versionMapping, false)
 }
 
-func updateNamespaceEntities(tenantService tenant.Service, t *tenant.Tenant, versionMapping map[string]string, failed bool) error {
+func updateNamespaceEntities(tenantService tenant.Service, t *tenant.Tenant, versionMapping map[env.Type]string, failed bool) error {
 	namespaces, err := tenantService.GetNamespaces(t.ID)
 	if err != nil {
 		return errs.Wrapf(err, "unable to get tenant namespaces")
@@ -213,7 +213,7 @@ func updateNamespaceEntities(tenantService tenant.Service, t *tenant.Tenant, ver
 	var found bool
 	var nsVersion string
 	for _, ns := range namespaces {
-		if nsVersion, found = versionMapping[string(ns.Type)]; found {
+		if nsVersion, found = versionMapping[ns.Type]; found {
 			if failed {
 				ns.State = "failed"
 			} else {
@@ -231,13 +231,13 @@ func updateNamespaceEntities(tenantService tenant.Service, t *tenant.Tenant, ver
 }
 
 type UpdateExecutor interface {
-	Update(ctx context.Context, tenantService tenant.Service, openshiftConfig openshift.Config, t *tenant.Tenant, envTypes []string) (map[string]string, error)
+	Update(ctx context.Context, tenantService tenant.Service, openshiftConfig openshift.Config, t *tenant.Tenant, envTypes []env.Type) (map[env.Type]string, error)
 }
 
 type TenantUpdater struct {
 }
 
-func (u TenantUpdater) Update(ctx context.Context, tenantService tenant.Service, openshiftConfig openshift.Config, t *tenant.Tenant, envTypes []string) (map[string]string, error) {
+func (u TenantUpdater) Update(ctx context.Context, tenantService tenant.Service, openshiftConfig openshift.Config, t *tenant.Tenant, envTypes []env.Type) (map[env.Type]string, error) {
 	return openshift.RawUpdateTenant(
 		ctx,
 		openshiftConfig,
@@ -329,7 +329,7 @@ func (c *TenantController) Show(ctx *app.ShowTenantContext) error {
 func InitTenant(ctx context.Context, masterURL string, service tenant.Service, currentTenant *tenant.Tenant) openshift.Callback {
 	var maxResourceQuotaStatusCheck int32 = 50 // technically a global retry count across all ResourceQuota on all Tenant Namespaces
 	var currentResourceQuotaStatusCheck int32  // default is 0
-	return func(statusCode int, method string, request, response map[interface{}]interface{}, versionMapping map[string]string) (string, map[interface{}]interface{}) {
+	return func(statusCode int, method string, request, response map[interface{}]interface{}, versionMapping map[env.Type]string) (string, map[interface{}]interface{}) {
 		log.Info(ctx, map[string]interface{}{
 			"status":      statusCode,
 			"method":      method,
@@ -358,7 +358,7 @@ func InitTenant(ctx context.Context, masterURL string, service tenant.Service, c
 			if env.GetKind(request) == env.ValKindProjectRequest {
 				name := env.GetName(request)
 				envType := tenant.GetNamespaceType(name, currentTenant.NsBaseName)
-				templatesVersion := versionMapping[string(envType)]
+				templatesVersion := versionMapping[envType]
 				service.SaveNamespace(&tenant.Namespace{
 					TenantID:  currentTenant.ID,
 					Name:      name,
@@ -376,7 +376,7 @@ func InitTenant(ctx context.Context, masterURL string, service tenant.Service, c
 			} else if env.GetKind(request) == env.ValKindNamespace {
 				name := env.GetName(request)
 				envType := tenant.GetNamespaceType(name, currentTenant.NsBaseName)
-				templatesVersion := versionMapping[string(envType)]
+				templatesVersion := versionMapping[envType]
 				service.SaveNamespace(&tenant.Namespace{
 					TenantID:  currentTenant.ID,
 					Name:      name,

--- a/controller/tenant_test.go
+++ b/controller/tenant_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/fabric8-services/fabric8-tenant/cluster"
 	"github.com/fabric8-services/fabric8-tenant/tenant"
 
+	"github.com/fabric8-services/fabric8-tenant/environment"
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
-	"github.com/fabric8-services/fabric8-tenant/environment"
 )
 
 var resolveCluster = func(ctx context.Context, target string) (cluster.Cluster, error) {

--- a/controller/tenant_test.go
+++ b/controller/tenant_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
+	"github.com/fabric8-services/fabric8-tenant/environment"
 )
 
 var resolveCluster = func(ctx context.Context, target string) (cluster.Cluster, error) {
@@ -30,7 +31,7 @@ func namespaces(ns1, ns2 time.Time) []*tenant.Namespace {
 			UpdatedAt: ns1,
 			MasterURL: "http://test1.org",
 			Name:      "test-che",
-			Type:      tenant.TypeChe,
+			Type:      environment.TypeChe,
 			Version:   "1.0",
 			State:     "created",
 		},
@@ -39,7 +40,7 @@ func namespaces(ns1, ns2 time.Time) []*tenant.Namespace {
 			UpdatedAt: ns2,
 			MasterURL: "http://test2.org",
 			Name:      "test-jenkins",
-			Type:      tenant.TypeJenkins,
+			Type:      environment.TypeJenkins,
 			Version:   "1.0",
 			State:     "created",
 		},

--- a/environment/service.go
+++ b/environment/service.go
@@ -30,20 +30,20 @@ var (
 	VersionFabric8TenantJenkinsQuotasFile string
 	VersionFabric8TenantCheQuotasFile     string
 	VersionFabric8TenantDeployFile        string
-	DefaultEnvTypes                       = []string{"che", "jenkins", "user", "run", "stage"}
+	DefaultEnvTypes                       = []Type{TypeChe, TypeJenkins, TypeRun, TypeStage, TypeUser}
 )
 
 type Templates []*Template
 
-func RetrieveMappedTemplates() map[string]Templates {
-	return map[string]Templates{
-		"run":   tmpl(deploy("run"), "fabric8-tenant-deploy.yml"),
-		"stage": tmpl(deploy("stage"), "fabric8-tenant-deploy.yml"),
-		"che": tmplWithQuota(versions(VersionFabric8TenantCheMtFile, VersionFabric8TenantCheQuotasFile),
+func RetrieveMappedTemplates() map[Type]Templates {
+	return map[Type]Templates{
+		TypeRun:   tmpl(deploy("run"), "fabric8-tenant-deploy.yml"),
+		TypeStage: tmpl(deploy("stage"), "fabric8-tenant-deploy.yml"),
+		TypeChe: tmplWithQuota(versions(VersionFabric8TenantCheMtFile, VersionFabric8TenantCheQuotasFile),
 			"fabric8-tenant-che-mt.yml", "fabric8-tenant-che-quotas.yml"),
-		"jenkins": tmplWithQuota(versions(VersionFabric8TenantJenkinsFile, VersionFabric8TenantJenkinsQuotasFile),
+		TypeJenkins: tmplWithQuota(versions(VersionFabric8TenantJenkinsFile, VersionFabric8TenantJenkinsQuotasFile),
 			"fabric8-tenant-jenkins.yml", "fabric8-tenant-jenkins-quotas.yml"),
-		"user": tmpl(versions(VersionFabric8TenantUserFile, ""), "fabric8-tenant-user.yml"),
+		TypeUser: tmpl(versions(VersionFabric8TenantUserFile, ""), "fabric8-tenant-user.yml"),
 	}
 }
 
@@ -92,15 +92,14 @@ func NewService(templatesRepo, templatesRepoBlob, templatesRepoDir string) *Serv
 }
 
 type EnvData struct {
-	NsType    string
-	Name      string
+	EnvType   Type
 	Templates Templates
 }
 
-func (s *Service) GetEnvData(ctx context.Context, envType string) (*EnvData, error) {
+func (s *Service) GetEnvData(ctx context.Context, envType Type) (*EnvData, error) {
 	var templates []*Template
 	var mappedTemplates = RetrieveMappedTemplates()
-	if envType == "che" {
+	if envType == TypeChe {
 		templates = mappedTemplates[envType]
 		err := getCheParams(ctx, templates[0].DefaultParams)
 		if err != nil {
@@ -117,8 +116,7 @@ func (s *Service) GetEnvData(ctx context.Context, envType string) (*EnvData, err
 
 	return &EnvData{
 		Templates: templates,
-		Name:      envType,
-		NsType:    envType,
+		EnvType:   envType,
 	}, nil
 }
 

--- a/environment/service_test.go
+++ b/environment/service_test.go
@@ -3,7 +3,6 @@ package environment_test
 import (
 	"context"
 	"github.com/fabric8-services/fabric8-tenant/environment"
-	"github.com/fabric8-services/fabric8-tenant/tenant"
 	"github.com/fabric8-services/fabric8-tenant/test/doubles"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -69,7 +68,7 @@ func TestGetAllTemplatesForAllTypes(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			assert.Equal(t, env.Name, envType)
+			assert.Equal(t, env.EnvType, envType)
 			switch envType {
 			case "che":
 				assert.Len(t, env.Templates, 2)
@@ -115,7 +114,7 @@ func TestAllTemplatesHaveNecessaryData(t *testing.T) {
 
 	for _, envType := range environment.DefaultEnvTypes {
 		nsName := "dev-" + envType
-		if envType == string(tenant.TypeUser) {
+		if envType == environment.TypeUser {
 			nsName = "dev"
 		}
 

--- a/environment/type.go
+++ b/environment/type.go
@@ -1,0 +1,47 @@
+package environment
+
+import (
+	"database/sql/driver"
+	"errors"
+)
+
+// Type describes which type of namespace this is
+type Type string
+
+// Represents the namespace type
+const (
+	TypeChe     Type = "che"
+	TypeJenkins Type = "jenkins"
+	TypeTest    Type = "test"
+	TypeStage   Type = "stage"
+	TypeRun     Type = "run"
+	TypeUser    Type = "user"
+	TypeCustom  Type = "custom"
+)
+
+// Value - Implementation of valuer for database/sql
+func (ns *Type) Value() (driver.Value, error) {
+	return string(*ns), nil
+}
+
+// Scan - Implement the database/sql scanner interface
+func (ns *Type) Scan(value interface{}) error {
+	if value == nil {
+		*ns = Type("")
+		return nil
+	}
+	if bv, err := driver.String.ConvertValue(value); err == nil {
+		// if this is a bool type
+		if v, ok := bv.(string); ok {
+			// set the value of the pointer yne to YesNoEnum(v)
+			*ns = Type(v)
+			return nil
+		}
+	}
+	// otherwise, return an error
+	return errors.New("failed to scan Type")
+}
+
+func (t Type) String() string {
+	return string(t)
+}

--- a/openshift/apply.go
+++ b/openshift/apply.go
@@ -120,7 +120,7 @@ metadata:
 )
 
 // Callback is called after initial action
-type Callback func(statusCode int, method string, request, response map[interface{}]interface{}, versionMapping map[string]string) (string, map[interface{}]interface{})
+type Callback func(statusCode int, method string, request, response map[interface{}]interface{}, versionMapping map[env.Type]string) (string, map[interface{}]interface{})
 type CallbackWithVersionMapping func(statusCode int, method string, request, response map[interface{}]interface{}) (string, map[interface{}]interface{})
 
 // ApplyOptions contains options for connecting to the target API

--- a/openshift/init_tenant.go
+++ b/openshift/init_tenant.go
@@ -34,7 +34,7 @@ func RawInitTenant(ctx context.Context, config Config, callback Callback, opensh
 	for key, val := range mapped {
 		namespaceType := tenant.GetNamespaceType(key, nsBaseName)
 
-		if namespaceType == tenant.TypeUser {
+		if namespaceType == env.TypeUser {
 			go func(namespace string, objects env.Objects, opts, userOpts ApplyOptions) {
 				defer wg.Done()
 				err := ApplyProcessed(Filter(objects, IsOfKind(env.ValKindProjectRequest, env.ValKindNamespace)), userOpts)
@@ -93,7 +93,7 @@ func RawInitTenant(ctx context.Context, config Config, callback Callback, opensh
 	return nil
 }
 
-func RawUpdateTenant(ctx context.Context, config Config, callback Callback, osUsername, nsBaseName string, envTypes []string) (map[string]string, error) {
+func RawUpdateTenant(ctx context.Context, config Config, callback Callback, osUsername, nsBaseName string, envTypes []env.Type) (map[env.Type]string, error) {
 	templs, versionMapping, err := LoadProcessedTemplates(ctx, config, osUsername, nsBaseName, envTypes)
 	if err != nil {
 		return versionMapping, err

--- a/openshift/init_tenant_test.go
+++ b/openshift/init_tenant_test.go
@@ -10,9 +10,10 @@ import (
 	"gopkg.in/h2non/gock.v1"
 	"net/http"
 	"testing"
+	"github.com/fabric8-services/fabric8-tenant/environment"
 )
 
-var emptyCallback = func(statusCode int, method string, request, response map[interface{}]interface{}, versionMapping map[string]string) (string, map[interface{}]interface{}) {
+var emptyCallback = func(statusCode int, method string, request, response map[interface{}]interface{}, versionMapping map[environment.Type]string) (string, map[interface{}]interface{}) {
 	return "", nil
 }
 

--- a/openshift/init_tenant_test.go
+++ b/openshift/init_tenant_test.go
@@ -3,6 +3,7 @@ package openshift_test
 import (
 	"context"
 	"github.com/fabric8-services/fabric8-tenant/auth/client"
+	"github.com/fabric8-services/fabric8-tenant/environment"
 	"github.com/fabric8-services/fabric8-tenant/openshift"
 	"github.com/fabric8-services/fabric8-tenant/test"
 	"github.com/stretchr/testify/assert"
@@ -10,7 +11,6 @@ import (
 	"gopkg.in/h2non/gock.v1"
 	"net/http"
 	"testing"
-	"github.com/fabric8-services/fabric8-tenant/environment"
 )
 
 var emptyCallback = func(statusCode int, method string, request, response map[interface{}]interface{}, versionMapping map[environment.Type]string) (string, map[interface{}]interface{}) {

--- a/openshift/process_template.go
+++ b/openshift/process_template.go
@@ -43,8 +43,8 @@ func IsNotOfKind(kinds ...string) FilterFunc {
 	}
 }
 
-func LoadProcessedTemplates(ctx context.Context, config Config, osUsername, nsBaseName string, envTypes []string) (environment.Objects, map[string]string, error) {
-	versionMapping := map[string]string{}
+func LoadProcessedTemplates(ctx context.Context, config Config, osUsername, nsBaseName string, envTypes []environment.Type) (environment.Objects, map[environment.Type]string, error) {
+	versionMapping := map[environment.Type]string{}
 	envService := environment.NewService(config.TemplatesRepo, config.TemplatesRepoBlob, config.TemplatesRepoDir)
 	vars := environment.CollectVars(osUsername, nsBaseName, config.MasterUser, config.OriginalConfig)
 	var objs environment.Objects

--- a/tenant/repository.go
+++ b/tenant/repository.go
@@ -24,7 +24,7 @@ type Service interface {
 	DeleteAll(tenantID uuid.UUID) error
 	NamespaceExists(nsName string) (bool, error)
 	ExistsWithNsBaseName(nsBaseName string) (bool, error)
-	GetTenantsToUpdate(typeWithVersion map[string]string, count int, commit string) ([]*Tenant, error)
+	GetTenantsToUpdate(typeWithVersion map[environment.Type]string, count int, commit string) ([]*Tenant, error)
 }
 
 func NewDBService(db *gorm.DB) Service {
@@ -124,7 +124,7 @@ func (s DBService) GetNamespaces(tenantID uuid.UUID) ([]*Namespace, error) {
 	return t, nil
 }
 
-func (s DBService) GetTenantsToUpdate(typeWithVersion map[string]string, count int, commit string) ([]*Tenant, error) {
+func (s DBService) GetTenantsToUpdate(typeWithVersion map[environment.Type]string, count int, commit string) ([]*Tenant, error) {
 	var tenants []*Tenant
 	nsSubQuery := s.db.Table(Namespace{}.TableName()).Select("tenant_id").
 		Where("state != 'failed' OR (state = 'failed' AND updated_by != ?)", commit)
@@ -214,8 +214,8 @@ func constructNsBaseName(repo Service, username string, number int) (string, err
 	}
 	for _, nsType := range environment.DefaultEnvTypes {
 		nsName := nsBaseName
-		if nsType != "user" {
-			nsName += "-" + nsType
+		if nsType != environment.TypeUser {
+			nsName += "-" + nsType.String()
 		}
 		exists, err := repo.NamespaceExists(nsName)
 		if err != nil {

--- a/tenant/repository_test.go
+++ b/tenant/repository_test.go
@@ -235,7 +235,7 @@ func updateAllTenants(t *testing.T, toUpdate []*tenant.Tenant, svc tenant.Servic
 			if failed {
 				ns.State = "failed"
 			} else {
-				ns.Version = mappedVersions[string(ns.Type)]
+				ns.Version = mappedVersions[ns.Type]
 				ns.State = "ready"
 			}
 			ns.UpdatedBy = "xyz"

--- a/tenant/tenant.go
+++ b/tenant/tenant.go
@@ -1,49 +1,11 @@
 package tenant
 
 import (
-	"database/sql/driver"
-	"errors"
 	"strings"
 	"time"
 
+	"github.com/fabric8-services/fabric8-tenant/environment"
 	"github.com/satori/go.uuid"
-)
-
-// NamespaceType describes which type of namespace this is
-type NamespaceType string
-
-// Value - Implementation of valuer for database/sql
-func (ns NamespaceType) Value() (driver.Value, error) {
-	return string(ns), nil
-}
-
-// Scan - Implement the database/sql scanner interface
-func (ns *NamespaceType) Scan(value interface{}) error {
-	if value == nil {
-		*ns = NamespaceType("")
-		return nil
-	}
-	if bv, err := driver.String.ConvertValue(value); err == nil {
-		// if this is a bool type
-		if v, ok := bv.(string); ok {
-			// set the value of the pointer yne to YesNoEnum(v)
-			*ns = NamespaceType(v)
-			return nil
-		}
-	}
-	// otherwise, return an error
-	return errors.New("failed to scan NamespaceType")
-}
-
-// Represents the namespace type
-const (
-	TypeChe     NamespaceType = "che"
-	TypeJenkins NamespaceType = "jenkins"
-	TypeTest    NamespaceType = "test"
-	TypeStage   NamespaceType = "stage"
-	TypeRun     NamespaceType = "run"
-	TypeUser    NamespaceType = "user"
-	TypeCustom  NamespaceType = "custom"
 )
 
 // Tenant is the owning OpenShift account
@@ -73,7 +35,7 @@ type Namespace struct {
 	DeletedAt *time.Time
 	Name      string
 	MasterURL string
-	Type      NamespaceType
+	Type      environment.Type
 	Version   string
 	State     string
 	UpdatedBy string
@@ -86,24 +48,24 @@ func (m Namespace) TableName() string {
 }
 
 // GetNamespaceType attempts to extract the namespace type based on namespace name
-func GetNamespaceType(name, nsBaseName string) NamespaceType {
+func GetNamespaceType(name, nsBaseName string) environment.Type {
 	if name == nsBaseName {
-		return TypeUser
+		return environment.TypeUser
 	}
 	if strings.HasSuffix(name, "-jenkins") {
-		return TypeJenkins
+		return environment.TypeJenkins
 	}
 	if strings.HasSuffix(name, "-che") {
-		return TypeChe
+		return environment.TypeChe
 	}
 	if strings.HasSuffix(name, "-test") {
-		return TypeTest
+		return environment.TypeTest
 	}
 	if strings.HasSuffix(name, "-stage") {
-		return TypeStage
+		return environment.TypeStage
 	}
 	if strings.HasSuffix(name, "-run") {
-		return TypeRun
+		return environment.TypeRun
 	}
-	return TypeCustom
+	return environment.TypeCustom
 }

--- a/tenant/tenant_test.go
+++ b/tenant/tenant_test.go
@@ -1,6 +1,7 @@
 package tenant_test
 
 import (
+	"github.com/fabric8-services/fabric8-tenant/environment"
 	"github.com/fabric8-services/fabric8-tenant/tenant"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -13,7 +14,7 @@ func TestGetNamespaceType(t *testing.T) {
 		namespaceType := tenant.GetNamespaceType("account-for-test", "account-for-test")
 
 		// then
-		assert.Equal(t, namespaceType, tenant.TypeUser)
+		assert.Equal(t, namespaceType, environment.TypeUser)
 	})
 
 	t.Run("should detect ns as run type when ends with run", func(t *testing.T) {
@@ -21,7 +22,7 @@ func TestGetNamespaceType(t *testing.T) {
 		namespaceType := tenant.GetNamespaceType("account-for-test-run", "account-for-test")
 
 		// then
-		assert.Equal(t, namespaceType, tenant.TypeRun)
+		assert.Equal(t, namespaceType, environment.TypeRun)
 	})
 
 	t.Run("should detect ns as stage type when ends with stage", func(t *testing.T) {
@@ -29,7 +30,7 @@ func TestGetNamespaceType(t *testing.T) {
 		namespaceType := tenant.GetNamespaceType("account-for-test-stage-stage", "account-for-stage")
 
 		// then
-		assert.Equal(t, namespaceType, tenant.TypeStage)
+		assert.Equal(t, namespaceType, environment.TypeStage)
 	})
 
 	t.Run("should detect ns as che type when ends with che", func(t *testing.T) {
@@ -37,7 +38,7 @@ func TestGetNamespaceType(t *testing.T) {
 		namespaceType := tenant.GetNamespaceType("che-che", "che")
 
 		// then
-		assert.Equal(t, namespaceType, tenant.TypeChe)
+		assert.Equal(t, namespaceType, environment.TypeChe)
 	})
 
 	t.Run("should detect ns as jenkins type when ends with jenkins", func(t *testing.T) {
@@ -45,7 +46,7 @@ func TestGetNamespaceType(t *testing.T) {
 		namespaceType := tenant.GetNamespaceType("any-run-stage-jenkins", "any-run-stage")
 
 		// then
-		assert.Equal(t, namespaceType, tenant.TypeJenkins)
+		assert.Equal(t, namespaceType, environment.TypeJenkins)
 	})
 
 	t.Run("should detect ns as custom type when ends with unknown suffix", func(t *testing.T) {
@@ -53,6 +54,6 @@ func TestGetNamespaceType(t *testing.T) {
 		namespaceType := tenant.GetNamespaceType("any-run-stage-custom", "any-run-stage")
 
 		// then
-		assert.Equal(t, namespaceType, tenant.TypeCustom)
+		assert.Equal(t, namespaceType, environment.TypeCustom)
 	})
 }

--- a/test/doubles/test_doubles.go
+++ b/test/doubles/test_doubles.go
@@ -58,9 +58,9 @@ func SetTemplateSameVersion(version string) {
 	environment.VersionFabric8TenantJenkinsQuotasFile = version
 }
 
-func GetMappedVersions(envTypes ...string) map[string]string {
+func GetMappedVersions(envTypes ...environment.Type) map[environment.Type]string {
 	mappedTemplates := environment.RetrieveMappedTemplates()
-	typesWithVersion := map[string]string{}
+	typesWithVersion := map[environment.Type]string{}
 	for _, envType := range envTypes {
 		typesWithVersion[envType] = mappedTemplates[envType].ConstructCompleteVersion()
 	}

--- a/test/testfixture/make_functions.go
+++ b/test/testfixture/make_functions.go
@@ -1,9 +1,10 @@
 package testfixture
 
 import (
+	"github.com/fabric8-services/fabric8-tenant/environment"
 	"github.com/fabric8-services/fabric8-tenant/tenant"
 	errs "github.com/pkg/errors"
-	uuid "github.com/satori/go.uuid"
+	"github.com/satori/go.uuid"
 )
 
 func makeTenants(fxt *TestFixture) error {
@@ -37,7 +38,7 @@ func makeNamespaces(fxt *TestFixture) error {
 	tenantService := tenant.NewDBService(fxt.db)
 	for i := range fxt.Namespaces {
 		fxt.Namespaces[i] = &tenant.Namespace{
-			Type:      tenant.TypeChe,
+			Type:      environment.TypeChe,
 			Name:      createRandomNamespaceName(),
 			MasterURL: "some.cluster.url",
 		}

--- a/test/testfixture/testfixture.go
+++ b/test/testfixture/testfixture.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/fabric8-services/fabric8-tenant/controller"
+	"github.com/fabric8-services/fabric8-tenant/environment"
 	"github.com/fabric8-services/fabric8-tenant/tenant"
 	"github.com/fabric8-services/fabric8-tenant/test/doubles"
 	"github.com/fabric8-services/fabric8-wit/resource"
@@ -178,18 +179,18 @@ func newFixture(db *gorm.DB, isolatedCreation bool, recipeFuncs ...RecipeFunctio
 	return &fxt, nil
 }
 
-func FillDB(t *testing.T, db *gorm.DB, numberOfTenants int, upToDate bool, state string, envTypes ...string) *TestFixture {
+func FillDB(t *testing.T, db *gorm.DB, numberOfTenants int, upToDate bool, state string, envTypes ...environment.Type) *TestFixture {
 	mappedVersions := testdoubles.GetMappedVersions(envTypes...)
 	return NewTestFixture(t, db, Tenants(numberOfTenants),
 		Namespaces(numberOfTenants*len(envTypes), func(fxt *TestFixture, idx int) error {
 			fxt.Namespaces[idx].TenantID = fxt.Tenants[int(idx/len(envTypes))].ID
-			fxt.Namespaces[idx].Type = tenant.NamespaceType(envTypes[idx%len(envTypes)])
+			fxt.Namespaces[idx].Type = environment.Type(envTypes[idx%len(envTypes)])
 			fxt.Namespaces[idx].MasterURL = "http://api.cluster1/"
 			fxt.Namespaces[idx].UpdatedAt = time.Now()
 			fxt.Namespaces[idx].UpdatedBy = controller.Commit
 			fxt.Namespaces[idx].State = state
 			if upToDate {
-				fxt.Namespaces[idx].Version = mappedVersions[string(fxt.Namespaces[idx].Type)]
+				fxt.Namespaces[idx].Version = mappedVersions[fxt.Namespaces[idx].Type]
 			} else {
 				fxt.Namespaces[idx].Version = "0000"
 			}

--- a/update/update.go
+++ b/update/update.go
@@ -35,7 +35,7 @@ func (u *TenantsUpdater) UpdateAllTenants() {
 
 	var followUp followUpFunc = func() error { return nil }
 
-	prepareAndAssignStart := func(repo Repository, envTypes []string) error {
+	prepareAndAssignStart := func(repo Repository, envTypes []environment.Type) error {
 		err := repo.PrepareForUpdating()
 		if err != nil {
 			return err
@@ -132,12 +132,12 @@ func (u *TenantsUpdater) isOlderThanTimeout(when time.Time) bool {
 	return when.Before(time.Now().Add(-u.config.GetAutomatedUpdateRetrySleep()))
 }
 
-func (u *TenantsUpdater) updateTenantsForTypes(envTypes []string) followUpFunc {
+func (u *TenantsUpdater) updateTenantsForTypes(envTypes []environment.Type) followUpFunc {
 	return func() error {
 		mappedTemplates := environment.RetrieveMappedTemplates()
 		tenantRepo := tenant.NewDBService(u.db)
 
-		typesWithVersion := map[string]string{}
+		typesWithVersion := map[environment.Type]string{}
 
 		for _, envType := range envTypes {
 			typesWithVersion[envType] = mappedTemplates[envType].ConstructCompleteVersion()
@@ -185,7 +185,7 @@ func (u *TenantsUpdater) setStatusAndVersionsAfterUpdate(repo Repository) error 
 	return repo.SaveTenantsUpdate(tenantUpdate)
 }
 
-func (u *TenantsUpdater) updateTenants(tenants []*tenant.Tenant, tenantRepo tenant.Service, envTypes []string) {
+func (u *TenantsUpdater) updateTenants(tenants []*tenant.Tenant, tenantRepo tenant.Service, envTypes []environment.Type) {
 	numberOfTriggeredUpdates := 0
 	var wg sync.WaitGroup
 
@@ -203,7 +203,7 @@ func (u *TenantsUpdater) updateTenants(tenants []*tenant.Tenant, tenantRepo tena
 	wg.Wait()
 }
 
-func updateTenant(wg *sync.WaitGroup, tnnt *tenant.Tenant, tenantRepo tenant.Service, envTypes []string, updater TenantsUpdater) {
+func updateTenant(wg *sync.WaitGroup, tnnt *tenant.Tenant, tenantRepo tenant.Service, envTypes []environment.Type, updater TenantsUpdater) {
 	defer wg.Done()
 
 	namespaces, err := tenantRepo.GetNamespaces(tnnt.ID)
@@ -218,7 +218,7 @@ func updateTenant(wg *sync.WaitGroup, tnnt *tenant.Tenant, tenantRepo tenant.Ser
 	for _, envType := range envTypes {
 		var namespace *tenant.Namespace
 		for _, ns := range namespaces {
-			if string(ns.Type) == envType {
+			if ns.Type == envType {
 				namespace = ns
 				break
 			}
@@ -261,8 +261,8 @@ var emptyTemplateRepoInfoSetter openshift.TemplateRepoInfoSetter = func(config o
 	return config
 }
 
-func checkVersions(tu *TenantsUpdate) ([]string, error) {
-	var types []string
+func checkVersions(tu *TenantsUpdate) ([]environment.Type, error) {
+	var types []environment.Type
 	for _, versionManager := range RetrieveVersionManagers() {
 		if !versionManager.IsVersionUpToDate(tu) {
 			addIfNotPresent(&types, versionManager.EnvTypes)
@@ -271,17 +271,17 @@ func checkVersions(tu *TenantsUpdate) ([]string, error) {
 	return types, nil
 }
 
-func addIfNotPresent(types *[]string, toAdd []tenant.NamespaceType) {
+func addIfNotPresent(types *[]environment.Type, toAdd []environment.Type) {
 	for _, toAddType := range toAdd {
 		found := false
 		for _, envType := range *types {
-			if envType == string(toAddType) {
+			if envType == toAddType {
 				found = true
 				break
 			}
 		}
 		if !found {
-			*types = append(*types, string(toAddType))
+			*types = append(*types, toAddType)
 		}
 	}
 }

--- a/update/update_test.go
+++ b/update/update_test.go
@@ -67,7 +67,7 @@ func (s *TenantsUpdaterTestSuite) TestUpdateAllTenantsForAllStatuses() {
 				namespaces, err := tenant.NewDBService(s.DB).GetNamespaces(tnnt.ID)
 				assert.NoError(t, err)
 				for _, ns := range namespaces {
-					assert.Equal(t, environment.RetrieveMappedTemplates()[string(ns.Type)].ConstructCompleteVersion(), ns.Version)
+					assert.Equal(t, environment.RetrieveMappedTemplates()[ns.Type].ConstructCompleteVersion(), ns.Version)
 					assert.Equal(t, "124abcd", ns.UpdatedBy)
 					assert.Equal(t, "ready", ns.State)
 					assert.True(t, before.Before(ns.UpdatedAt))
@@ -135,7 +135,7 @@ func (s *TenantsUpdaterTestSuite) TestDoNotUpdateAnythingWhenAllNamespacesAreUpT
 				for _, ns := range namespaces {
 					assert.Equal(t, "124abcd", ns.UpdatedBy)
 					assert.Equal(t, "ready", ns.State)
-					assert.Equal(t, environment.RetrieveMappedTemplates()[string(ns.Type)].ConstructCompleteVersion(), ns.Version)
+					assert.Equal(t, environment.RetrieveMappedTemplates()[ns.Type].ConstructCompleteVersion(), ns.Version)
 					assert.True(t, after.After(ns.UpdatedAt))
 				}
 			}
@@ -338,7 +338,7 @@ func Uint64(v uint64) *uint64 {
 	return &v
 }
 
-func (e *DummyUpdateExecutor) Update(ctx context.Context, tenantService tenant.Service, openshiftConfig openshift.Config, t *tenant.Tenant, envTypes []string) (map[string]string, error) {
+func (e *DummyUpdateExecutor) Update(ctx context.Context, tenantService tenant.Service, openshiftConfig openshift.Config, t *tenant.Tenant, envTypes []environment.Type) (map[environment.Type]string, error) {
 	atomic.AddUint64(e.numberOfCalls, 1)
 
 	time.Sleep(e.timeToSleep)

--- a/update/versions.go
+++ b/update/versions.go
@@ -2,7 +2,6 @@ package update
 
 import (
 	"github.com/fabric8-services/fabric8-tenant/environment"
-	"github.com/fabric8-services/fabric8-tenant/tenant"
 )
 
 func RetrieveVersionManagers() []*VersionManager {
@@ -12,53 +11,53 @@ func RetrieveVersionManagers() []*VersionManager {
 				return tu.LastVersionFabric8TenantUserFile
 			}, func(tu *TenantsUpdate, version string) {
 				tu.LastVersionFabric8TenantUserFile = version
-			}, tenant.TypeUser),
+			}, environment.TypeUser),
 
 		versionManager(environment.VersionFabric8TenantCheMtFile,
 			func(tu *TenantsUpdate) string {
 				return tu.LastVersionFabric8TenantCheMtFile
 			}, func(tu *TenantsUpdate, version string) {
 				tu.LastVersionFabric8TenantCheMtFile = version
-			}, tenant.TypeChe),
+			}, environment.TypeChe),
 
 		versionManager(environment.VersionFabric8TenantCheQuotasFile,
 			func(tu *TenantsUpdate) string {
 				return tu.LastVersionFabric8TenantCheQuotasFile
 			}, func(tu *TenantsUpdate, version string) {
 				tu.LastVersionFabric8TenantCheQuotasFile = version
-			}, tenant.TypeChe),
+			}, environment.TypeChe),
 
 		versionManager(environment.VersionFabric8TenantJenkinsFile,
 			func(tu *TenantsUpdate) string {
 				return tu.LastVersionFabric8TenantJenkinsFile
 			}, func(tu *TenantsUpdate, version string) {
 				tu.LastVersionFabric8TenantJenkinsFile = version
-			}, tenant.TypeJenkins),
+			}, environment.TypeJenkins),
 
 		versionManager(environment.VersionFabric8TenantJenkinsQuotasFile,
 			func(tu *TenantsUpdate) string {
 				return tu.LastVersionFabric8TenantJenkinsQuotasFile
 			}, func(tu *TenantsUpdate, version string) {
 				tu.LastVersionFabric8TenantJenkinsQuotasFile = version
-			}, tenant.TypeJenkins),
+			}, environment.TypeJenkins),
 
 		versionManager(environment.VersionFabric8TenantDeployFile,
 			func(tu *TenantsUpdate) string {
 				return tu.LastVersionFabric8TenantDeployFile
 			}, func(tu *TenantsUpdate, version string) {
 				tu.LastVersionFabric8TenantDeployFile = version
-			}, tenant.TypeStage, tenant.TypeRun),
+			}, environment.TypeStage, environment.TypeRun),
 	}
 }
 
 type VersionManager struct {
 	Version           string
-	EnvTypes          []tenant.NamespaceType
+	EnvTypes          []environment.Type
 	GetStoredVersion  func(tu *TenantsUpdate) string
 	setCurrentVersion func(tu *TenantsUpdate, versionToSet string)
 }
 
-func versionManager(version string, getStoredVersion func(tu *TenantsUpdate) string, setCurrentVersion func(tu *TenantsUpdate, version string), envTypes ...tenant.NamespaceType) *VersionManager {
+func versionManager(version string, getStoredVersion func(tu *TenantsUpdate) string, setCurrentVersion func(tu *TenantsUpdate, version string), envTypes ...environment.Type) *VersionManager {
 	return &VersionManager{
 		Version:           version,
 		EnvTypes:          envTypes,


### PR DESCRIPTION
as part of an attempt to lower the number of changes in the huge refactoring [PR](https://github.com/fabric8-services/fabric8-tenant/pull/673), I'm bringing one smaller part as a separated PR.

This one replaces `NamespaceType` by `environment.Type` and uses it in all cases where the code refers to the type of environment/namespace