### PR TITLE
use enum NamespaceState for states stored in namespaces

### DIFF
--- a/controller/tenant.go
+++ b/controller/tenant.go
@@ -215,9 +215,9 @@ func updateNamespaceEntities(tenantService tenant.Service, t *tenant.Tenant, ver
 	for _, ns := range namespaces {
 		if nsVersion, found = versionMapping[string(ns.Type)]; found {
 			if failed {
-				ns.State = "failed"
+				ns.State = tenant.Failed
 			} else {
-				ns.State = "ready"
+				ns.State = tenant.Ready
 				ns.Version = nsVersion
 			}
 			ns.UpdatedBy = Commit
@@ -362,7 +362,7 @@ func InitTenant(ctx context.Context, masterURL string, service tenant.Service, c
 				service.SaveNamespace(&tenant.Namespace{
 					TenantID:  currentTenant.ID,
 					Name:      name,
-					State:     "created",
+					State:     tenant.Ready,
 					Version:   templatesVersion,
 					Type:      envType,
 					MasterURL: masterURL,
@@ -380,7 +380,7 @@ func InitTenant(ctx context.Context, masterURL string, service tenant.Service, c
 				service.SaveNamespace(&tenant.Namespace{
 					TenantID:  currentTenant.ID,
 					Name:      name,
-					State:     "created",
+					State:     tenant.Ready,
 					Version:   templatesVersion,
 					Type:      envType,
 					MasterURL: masterURL,
@@ -443,6 +443,7 @@ func convertTenant(ctx context.Context, tenant *tenant.Tenant, namespaces []*ten
 			c = cluster.Cluster{}
 		}
 		tenantType := string(ns.Type)
+		namespaceState := ns.State.String()
 		result.Attributes.Namespaces = append(
 			result.Attributes.Namespaces,
 			&app.NamespaceAttributes{
@@ -456,7 +457,7 @@ func convertTenant(ctx context.Context, tenant *tenant.Tenant, namespaces []*ten
 				Name:                     &ns.Name,
 				Type:                     &tenantType,
 				Version:                  &ns.Version,
-				State:                    &ns.State,
+				State:                    &namespaceState,
 				ClusterCapacityExhausted: &c.CapacityExhausted,
 			})
 	}

--- a/controller/tenant_test.go
+++ b/controller/tenant_test.go
@@ -32,7 +32,7 @@ func namespaces(ns1, ns2 time.Time) []*tenant.Namespace {
 			Name:      "test-che",
 			Type:      tenant.TypeChe,
 			Version:   "1.0",
-			State:     "created",
+			State:     tenant.Ready,
 		},
 		{
 			CreatedAt: ns2,
@@ -41,7 +41,7 @@ func namespaces(ns1, ns2 time.Time) []*tenant.Namespace {
 			Name:      "test-jenkins",
 			Type:      tenant.TypeJenkins,
 			Version:   "1.0",
-			State:     "created",
+			State:     tenant.Ready,
 		},
 	}
 }
@@ -79,7 +79,7 @@ func Test_convertTenant(t *testing.T) {
 					Name:                     strToPtr("test-che"),
 					Type:                     strToPtr("che"),
 					Version:                  strToPtr("1.0"),
-					State:                    strToPtr("created"),
+					State:                    strToPtr("ready"),
 					ClusterCapacityExhausted: boolToPtr(true),
 				},
 				{
@@ -93,7 +93,7 @@ func Test_convertTenant(t *testing.T) {
 					Name:                     strToPtr("test-jenkins"),
 					Type:                     strToPtr("jenkins"),
 					Version:                  strToPtr("1.0"),
-					State:                    strToPtr("created"),
+					State:                    strToPtr("ready"),
 					ClusterCapacityExhausted: boolToPtr(true),
 				},
 			},

--- a/tenant/repository_test.go
+++ b/tenant/repository_test.go
@@ -233,10 +233,10 @@ func updateAllTenants(t *testing.T, toUpdate []*tenant.Tenant, svc tenant.Servic
 		assert.NoError(t, err)
 		for _, ns := range namespaces {
 			if failed {
-				ns.State = "failed"
+				ns.State = tenant.Failed
 			} else {
 				ns.Version = mappedVersions[string(ns.Type)]
-				ns.State = "ready"
+				ns.State = tenant.Ready
 			}
 			ns.UpdatedBy = "xyz"
 			assert.NoError(t, svc.SaveNamespace(ns))

--- a/tenant/tenant.go
+++ b/tenant/tenant.go
@@ -75,7 +75,7 @@ type Namespace struct {
 	MasterURL string
 	Type      NamespaceType
 	Version   string
-	State     string
+	State     NamespaceState
 	UpdatedBy string
 }
 
@@ -106,4 +106,41 @@ func GetNamespaceType(name, nsBaseName string) NamespaceType {
 		return TypeRun
 	}
 	return TypeCustom
+}
+
+type NamespaceState string
+
+const (
+	Provisioning NamespaceState = "provisioning"
+	Updating     NamespaceState = "updating"
+	Ready        NamespaceState = "ready"
+	Failed       NamespaceState = "failed"
+)
+
+func (s NamespaceState) String() string {
+	return string(s)
+}
+
+// Value - Implementation of valuer for database/sql
+func (ns *NamespaceState) Value() (driver.Value, error) {
+	return string(*ns), nil
+}
+
+// Scan - Implement the database/sql scanner interface
+func (ns *NamespaceState) Scan(value interface{}) error {
+	if value == nil {
+		*ns = NamespaceState(Ready)
+		return nil
+	}
+	if bv, err := driver.String.ConvertValue(value); err == nil {
+		// if this is a bool type
+		if v, ok := bv.(string); ok {
+			// set the value of the pointer yne to YesNoEnum(v)
+			*ns = NamespaceState(v)
+			return nil
+		}
+	}
+	// otherwise, set ready state
+	*ns = Ready
+	return nil
 }

--- a/test/testfixture/testfixture.go
+++ b/test/testfixture/testfixture.go
@@ -178,7 +178,7 @@ func newFixture(db *gorm.DB, isolatedCreation bool, recipeFuncs ...RecipeFunctio
 	return &fxt, nil
 }
 
-func FillDB(t *testing.T, db *gorm.DB, numberOfTenants int, upToDate bool, state string, envTypes ...string) *TestFixture {
+func FillDB(t *testing.T, db *gorm.DB, numberOfTenants int, upToDate bool, state tenant.NamespaceState, envTypes ...string) *TestFixture {
 	mappedVersions := testdoubles.GetMappedVersions(envTypes...)
 	return NewTestFixture(t, db, Tenants(numberOfTenants),
 		Namespaces(numberOfTenants*len(envTypes), func(fxt *TestFixture, idx int) error {

--- a/update/update_minishift_test.go
+++ b/update/update_minishift_test.go
@@ -119,7 +119,7 @@ func (s *AutomatedUpdateMinishiftTestSuite) verifyAreUpdated(tenantIDs []uuid.UU
 				assert.True(t, wasBefore.Before(ns.UpdatedAt))
 				assert.Contains(t, ns.Version, "2abcd")
 				assert.NotContains(t, ns.Version, "1abcd")
-				assert.Equal(t, "ready", ns.State)
+				assert.Equal(t, tenant.Ready, ns.State)
 			}
 			mappedObjects, masterOpts := s.GetMappedTemplateObjects(tnnt.NsBaseName)
 			minishift.VerifyObjectsPresence(t, mappedObjects, masterOpts, "2abcd", false)

--- a/update/update_test.go
+++ b/update/update_test.go
@@ -46,7 +46,7 @@ func (s *TenantsUpdaterTestSuite) TestUpdateAllTenantsForAllStatuses() {
 	for _, status := range []string{"finished", "updating", "failed"} {
 		s.T().Run(fmt.Sprintf("running automated update process whould pass when status %s is set", status), func(t *testing.T) {
 			*updateExecutor.numberOfCalls = 0
-			fxt := tf.FillDB(t, s.DB, 19, false, "ready", environment.DefaultEnvTypes...)
+			fxt := tf.FillDB(t, s.DB, 19, false, tenant.Ready, environment.DefaultEnvTypes...)
 			controller.Commit = "124abcd"
 			before := time.Now()
 
@@ -69,7 +69,7 @@ func (s *TenantsUpdaterTestSuite) TestUpdateAllTenantsForAllStatuses() {
 				for _, ns := range namespaces {
 					assert.Equal(t, environment.RetrieveMappedTemplates()[string(ns.Type)].ConstructCompleteVersion(), ns.Version)
 					assert.Equal(t, "124abcd", ns.UpdatedBy)
-					assert.Equal(t, "ready", ns.State)
+					assert.Equal(t, tenant.Ready, ns.State)
 					assert.True(t, before.Before(ns.UpdatedAt))
 				}
 			}
@@ -113,7 +113,7 @@ func (s *TenantsUpdaterTestSuite) TestDoNotUpdateAnythingWhenAllNamespacesAreUpT
 
 		s.T().Run(fmt.Sprintf("running automated update process should pass (without updating anything) when status %s is set", status), func(t *testing.T) {
 			*updateExecutor.numberOfCalls = 0
-			fxt := tf.FillDB(t, s.DB, 5, true, "ready", environment.DefaultEnvTypes...)
+			fxt := tf.FillDB(t, s.DB, 5, true, tenant.Ready, environment.DefaultEnvTypes...)
 			after := time.Now()
 
 			s.tx(t, func(repo update.Repository) error {
@@ -134,7 +134,7 @@ func (s *TenantsUpdaterTestSuite) TestDoNotUpdateAnythingWhenAllNamespacesAreUpT
 				assert.NoError(t, err)
 				for _, ns := range namespaces {
 					assert.Equal(t, "124abcd", ns.UpdatedBy)
-					assert.Equal(t, "ready", ns.State)
+					assert.Equal(t, tenant.Ready, ns.State)
 					assert.Equal(t, environment.RetrieveMappedTemplates()[string(ns.Type)].ConstructCompleteVersion(), ns.Version)
 					assert.True(t, after.After(ns.UpdatedAt))
 				}
@@ -153,7 +153,7 @@ func (s *TenantsUpdaterTestSuite) TestWhenExecutorFailsThenStatusFailed() {
 
 	testdoubles.SetTemplateVersions()
 	controller.Commit = "124abcd"
-	fxt := tf.FillDB(s.T(), s.DB, 1, false, "ready", environment.DefaultEnvTypes...)
+	fxt := tf.FillDB(s.T(), s.DB, 1, false, tenant.Ready, environment.DefaultEnvTypes...)
 	s.tx(s.T(), func(repo update.Repository) error {
 		return updateVersionsTo(repo, "0")
 	})
@@ -171,7 +171,7 @@ func (s *TenantsUpdaterTestSuite) TestWhenExecutorFailsThenStatusFailed() {
 		assert.NoError(s.T(), err)
 		for _, ns := range namespaces {
 			assert.Equal(s.T(), "xyz", ns.UpdatedBy)
-			assert.Equal(s.T(), "failed", ns.State)
+			assert.Equal(s.T(), tenant.Failed, ns.State)
 			assert.Equal(s.T(), "0000", ns.Version)
 			assert.True(s.T(), before.Before(ns.UpdatedAt))
 		}
@@ -219,7 +219,7 @@ func (s *TenantsUpdaterTestSuite) prepareForParallelTest(count int, timeToWait, 
 	defer gock.Off()
 	createMocks()
 	testdoubles.SetTemplateVersions()
-	tf.FillDB(s.T(), s.DB, 5, false, "ready", environment.DefaultEnvTypes...)
+	tf.FillDB(s.T(), s.DB, 5, false, tenant.Ready, environment.DefaultEnvTypes...)
 	s.tx(s.T(), func(repo update.Repository) error {
 		return updateVersionsTo(repo, "0")
 	})


### PR DESCRIPTION
as part of an attempt to lower the number of changes in the huge refactoring [PR](https://github.com/fabric8-services/fabric8-tenant/pull/673), I'm bringing one smaller part as a separated PR.

This one introduces `NamespaceState` as an enum used for namespace states 