### PR TITLE
move status vas to configuration pkg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ CLEAN_TARGETS =
 
 # Pass in build time variables to main
 LDFLAGS_FOR_TEMPLATES=$(foreach template-path, $(TEMPLATES), $(call set-latest-commit-sha,$(template-path)))
-LDFLAGS=-ldflags "-X ${PACKAGE_NAME}/controller.Commit=${COMMIT} -X ${PACKAGE_NAME}/controller.BuildTime=${BUILD_TIME} $(LDFLAGS_FOR_TEMPLATES)"
+LDFLAGS=-ldflags "-X ${PACKAGE_NAME}/configuration.Commit=${COMMIT} -X ${PACKAGE_NAME}/configuration.BuildTime=${BUILD_TIME} $(LDFLAGS_FOR_TEMPLATES)"
 
 define set-latest-commit-sha
 -X ${PACKAGE_NAME}/environment.$(call get-variable-name, $(1))=$(shell git log -n 1 --pretty=format:%h -- $(1))

--- a/configuration/status.go
+++ b/configuration/status.go
@@ -1,0 +1,12 @@
+package configuration
+
+import "time"
+
+var (
+	// Commit current build commit set by build script
+	Commit = "0"
+	// BuildTime set by build script in ISO 8601 (UTC) format: YYYY-MM-DDThh:mm:ssTZD (see https://www.w3.org/TR/NOTE-datetime for details)
+	BuildTime = "0"
+	// StartTime in ISO 8601 (UTC) format
+	StartTime = time.Now().UTC().Format("2006-01-02T15:04:05Z")
+)

--- a/controller/status.go
+++ b/controller/status.go
@@ -1,20 +1,10 @@
 package controller
 
 import (
-	"time"
-
 	"github.com/fabric8-services/fabric8-tenant/app"
+	"github.com/fabric8-services/fabric8-tenant/configuration"
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
-)
-
-var (
-	// Commit current build commit set by build script
-	Commit = "0"
-	// BuildTime set by build script in ISO 8601 (UTC) format: YYYY-MM-DDThh:mm:ssTZD (see https://www.w3.org/TR/NOTE-datetime for details)
-	BuildTime = "0"
-	// StartTime in ISO 8601 (UTC) format
-	StartTime = time.Now().UTC().Format("2006-01-02T15:04:05Z")
 )
 
 // StatusController implements the status resource.
@@ -34,9 +24,9 @@ func NewStatusController(service *goa.Service, db *gorm.DB) *StatusController {
 // Show runs the show action.
 func (c *StatusController) Show(ctx *app.ShowStatusContext) error {
 	res := &app.Status{}
-	res.Commit = Commit
-	res.BuildTime = BuildTime
-	res.StartTime = StartTime
+	res.Commit = configuration.Commit
+	res.BuildTime = configuration.BuildTime
+	res.StartTime = configuration.StartTime
 
 	_, err := c.db.DB().Exec("select 1")
 	if err != nil {

--- a/controller/tenant.go
+++ b/controller/tenant.go
@@ -220,7 +220,7 @@ func updateNamespaceEntities(tenantService tenant.Service, t *tenant.Tenant, ver
 				ns.State = "ready"
 				ns.Version = nsVersion
 			}
-			ns.UpdatedBy = Commit
+			ns.UpdatedBy = configuration.Commit
 			err := tenantService.SaveNamespace(ns)
 			if err != nil {
 				return errs.Wrapf(err, "unable to save tenant namespace %+v", ns)
@@ -366,7 +366,7 @@ func InitTenant(ctx context.Context, masterURL string, service tenant.Service, c
 					Version:   templatesVersion,
 					Type:      envType,
 					MasterURL: masterURL,
-					UpdatedBy: Commit,
+					UpdatedBy: configuration.Commit,
 				})
 
 				// HACK to workaround osio applying some dsaas-user permissions async
@@ -384,7 +384,7 @@ func InitTenant(ctx context.Context, masterURL string, service tenant.Service, c
 					Version:   templatesVersion,
 					Type:      envType,
 					MasterURL: masterURL,
-					UpdatedBy: Commit,
+					UpdatedBy: configuration.Commit,
 				})
 			} else if env.GetKind(request) == env.ValKindResourceQuota {
 				// trigger a check status loop

--- a/main.go
+++ b/main.go
@@ -106,7 +106,7 @@ func main() {
 
 	openshiftService := openshift.NewService()
 
-	haltSentry, err := sentry.InitializeLogger(config, controller.Commit)
+	haltSentry, err := sentry.InitializeLogger(config, configuration.Commit)
 	if err != nil {
 		log.Panic(nil, map[string]interface{}{
 			"err": err,
@@ -135,9 +135,9 @@ func main() {
 	tenantsCtrl := controller.NewTenantsController(service, tenantService, clusterService, authService, openshiftService)
 	app.MountTenantsController(service, tenantsCtrl)
 
-	log.Logger().Infoln("Git Commit SHA: ", controller.Commit)
-	log.Logger().Infoln("UTC Build Time: ", controller.BuildTime)
-	log.Logger().Infoln("UTC Start Time: ", controller.StartTime)
+	log.Logger().Infoln("Git Commit SHA: ", configuration.Commit)
+	log.Logger().Infoln("UTC Build Time: ", configuration.BuildTime)
+	log.Logger().Infoln("UTC Start Time: ", configuration.StartTime)
 	log.Logger().Infoln("Dev mode:       ", config.IsDeveloperModeEnabled())
 	log.Logger().Infoln("Auth URL:       ", config.GetAuthURL())
 

--- a/tenant/repository_test.go
+++ b/tenant/repository_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"fmt"
-	"github.com/fabric8-services/fabric8-tenant/controller"
+	"github.com/fabric8-services/fabric8-tenant/configuration"
 	"github.com/fabric8-services/fabric8-tenant/environment"
 	"github.com/fabric8-services/fabric8-tenant/tenant"
 	"github.com/fabric8-services/fabric8-tenant/test"
@@ -149,7 +149,7 @@ func (s *TenantServiceTestSuite) TestLookupTenantByNamespace() {
 func (s *TenantServiceTestSuite) TestGetAllTenantsToUpdate() {
 	s.T().Run("returns all tenants", func(t *testing.T) {
 		// given
-		controller.Commit = "123abc"
+		configuration.Commit = "123abc"
 		testdoubles.SetTemplateVersions()
 		tf.FillDB(t, s.DB, 3, false, "ready", environment.DefaultEnvTypes...)
 		svc := tenant.NewDBService(s.DB)
@@ -164,7 +164,7 @@ func (s *TenantServiceTestSuite) TestGetAllTenantsToUpdate() {
 
 	s.T().Run("returns only the limited number of tenants", func(t *testing.T) {
 		// given
-		controller.Commit = "123abc"
+		configuration.Commit = "123abc"
 		testdoubles.SetTemplateVersions()
 		tf.FillDB(t, s.DB, 10, false, "ready", environment.DefaultEnvTypes...)
 		svc := tenant.NewDBService(s.DB)
@@ -181,7 +181,7 @@ func (s *TenantServiceTestSuite) TestGetAllTenantsToUpdate() {
 func (s *TenantServiceTestSuite) TestGetAllTenantsToUpdateBatchByBatch() {
 	s.T().Run("will need to call GetTenantsToUpdate three times to get all tenants to update", func(t *testing.T) {
 		// given
-		controller.Commit = "123abc"
+		configuration.Commit = "123abc"
 		testdoubles.SetTemplateVersions()
 		fxt := tf.FillDB(t, s.DB, 11, false, "ready", environment.DefaultEnvTypes...)
 		svc := tenant.NewDBService(s.DB)
@@ -265,9 +265,9 @@ func (s *TenantServiceTestSuite) TestGetSubsetOfFailedTenantsToUpdate() {
 	s.T().Run("returns only those tenants whose namespaces have different updated_by", func(t *testing.T) {
 		// given
 		testdoubles.SetTemplateVersions()
-		controller.Commit = "123abc"
+		configuration.Commit = "123abc"
 		previouslyFailed := tf.FillDB(t, s.DB, 1, false, "failed", environment.DefaultEnvTypes...)
-		controller.Commit = "234bcd"
+		configuration.Commit = "234bcd"
 		tf.FillDB(t, s.DB, 6, false, "failed", environment.DefaultEnvTypes...)
 
 		svc := tenant.NewDBService(s.DB)
@@ -286,7 +286,7 @@ func (s *TenantServiceTestSuite) TestGetSubsetOfTenantsThatAreOutdatedToUpdate()
 	s.T().Run("returns only those tenants whose namespaces have different version", func(t *testing.T) {
 		// given
 		testdoubles.SetTemplateVersions()
-		controller.Commit = "123abc"
+		configuration.Commit = "123abc"
 		outdated := tf.FillDB(t, s.DB, 1, false, "ready", environment.DefaultEnvTypes...)
 		tf.FillDB(t, s.DB, 6, true, "ready", environment.DefaultEnvTypes...)
 

--- a/test/testfixture/testfixture.go
+++ b/test/testfixture/testfixture.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/fabric8-services/fabric8-tenant/controller"
+	"github.com/fabric8-services/fabric8-tenant/configuration"
 	"github.com/fabric8-services/fabric8-tenant/tenant"
 	"github.com/fabric8-services/fabric8-tenant/test/doubles"
 	"github.com/fabric8-services/fabric8-wit/resource"
@@ -186,7 +186,7 @@ func FillDB(t *testing.T, db *gorm.DB, numberOfTenants int, upToDate bool, state
 			fxt.Namespaces[idx].Type = tenant.NamespaceType(envTypes[idx%len(envTypes)])
 			fxt.Namespaces[idx].MasterURL = "http://api.cluster1/"
 			fxt.Namespaces[idx].UpdatedAt = time.Now()
-			fxt.Namespaces[idx].UpdatedBy = controller.Commit
+			fxt.Namespaces[idx].UpdatedBy = configuration.Commit
 			fxt.Namespaces[idx].State = state
 			if upToDate {
 				fxt.Namespaces[idx].Version = mappedVersions[string(fxt.Namespaces[idx].Type)]

--- a/update/update.go
+++ b/update/update.go
@@ -86,7 +86,7 @@ func (u *TenantsUpdater) UpdateAllTenants() {
 
 func HandleTenantUpdateError(db *gorm.DB, err error) {
 	sentry.LogError(nil, map[string]interface{}{
-		"commit": controller.Commit,
+		"commit": configuration.Commit,
 		"err":    err,
 	}, err, "automatic tenant update failed")
 	err = Transaction(db, lock(func(repo Repository) error {
@@ -94,7 +94,7 @@ func HandleTenantUpdateError(db *gorm.DB, err error) {
 	}))
 	if err != nil {
 		sentry.LogError(nil, map[string]interface{}{
-			"commit": controller.Commit,
+			"commit": configuration.Commit,
 			"err":    err,
 		}, err, "unable to set state to failed in tenants_update table")
 	}
@@ -144,7 +144,7 @@ func (u *TenantsUpdater) updateTenantsForTypes(envTypes []string) followUpFunc {
 		}
 
 		for {
-			toUpdate, err := tenantRepo.GetTenantsToUpdate(typesWithVersion, 100, controller.Commit)
+			toUpdate, err := tenantRepo.GetTenantsToUpdate(typesWithVersion, 100, configuration.Commit)
 			if err != nil {
 				return err
 			}

--- a/update/update_test.go
+++ b/update/update_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/fabric8-services/fabric8-tenant/cluster"
+	"github.com/fabric8-services/fabric8-tenant/configuration"
 	"github.com/fabric8-services/fabric8-tenant/controller"
 	"github.com/fabric8-services/fabric8-tenant/environment"
 	"github.com/fabric8-services/fabric8-tenant/openshift"
@@ -47,7 +48,7 @@ func (s *TenantsUpdaterTestSuite) TestUpdateAllTenantsForAllStatuses() {
 		s.T().Run(fmt.Sprintf("running automated update process whould pass when status %s is set", status), func(t *testing.T) {
 			*updateExecutor.numberOfCalls = 0
 			fxt := tf.FillDB(t, s.DB, 19, false, "ready", environment.DefaultEnvTypes...)
-			controller.Commit = "124abcd"
+			configuration.Commit = "124abcd"
 			before := time.Now()
 
 			s.tx(t, func(repo update.Repository) error {
@@ -107,7 +108,7 @@ func (s *TenantsUpdaterTestSuite) TestDoNotUpdateAnythingWhenAllNamespacesAreUpT
 	tenantsUpdater, reset := s.newTenantsUpdater(updateExecutor, 0)
 	defer reset()
 	testdoubles.SetTemplateVersions()
-	controller.Commit = "124abcd"
+	configuration.Commit = "124abcd"
 
 	for _, status := range []string{"finished", "updating", "failed"} {
 
@@ -152,13 +153,13 @@ func (s *TenantsUpdaterTestSuite) TestWhenExecutorFailsThenStatusFailed() {
 	defer reset()
 
 	testdoubles.SetTemplateVersions()
-	controller.Commit = "124abcd"
+	configuration.Commit = "124abcd"
 	fxt := tf.FillDB(s.T(), s.DB, 1, false, "ready", environment.DefaultEnvTypes...)
 	s.tx(s.T(), func(repo update.Repository) error {
 		return updateVersionsTo(repo, "0")
 	})
 
-	controller.Commit = "xyz"
+	configuration.Commit = "xyz"
 	before := time.Now()
 
 	// when


### PR DESCRIPTION
as part of an attempt to lower the number of changes in the huge refactoring [PR](https://github.com/fabric8-services/fabric8-tenant/pull/673), I'm bringing one smaller part as a separated PR.

This one moves the variables originally specified in the status endpoint to `configuration` package. It's used also in other packages and if it stayed in `controller` pkg then it would end up with package dependency cycle