### PR TITLE
fix: use apostrophes for declaring the default value

### DIFF
--- a/OpenShiftTemplate.yml
+++ b/OpenShiftTemplate.yml
@@ -182,4 +182,4 @@ parameters:
 - name: IMAGE_TAG
   value: latest
 - name: f8_automated_update_enabled
-  value: false
+  value: 'false'


### PR DESCRIPTION
otherwise it fails
Tested by: `oc process -f OpenShiftTemplate.yml`