### PR TITLE
issue(#718): update only outdated or failed namespaces

### DIFF
--- a/controller/tenants_test.go
+++ b/controller/tenants_test.go
@@ -181,7 +181,7 @@ func (s *TenantsControllerTestSuite) TestFailedDeleteTenants() {
 
 			svc, ctrl, reset := s.newTestTenantsController()
 			defer reset()
-			fxt := tf.FillDB(t, s.DB, tf.AddTenantsNamed("baz"), true, tf.AddNamespaces(environment.TypeUser, environment.TypeChe).State(tenant.Ready))
+			fxt := tf.FillDB(t, s.DB, tf.AddTenantsNamed("baz"), tf.AddNamespaces(environment.TypeUser, environment.TypeChe).State(tenant.Ready))
 
 			// when
 			goatest.DeleteTenantsInternalServerError(t, createValidSAContext("fabric8-auth"), svc, ctrl, fxt.Tenants[0].ID)

--- a/controller/update_test.go
+++ b/controller/update_test.go
@@ -94,8 +94,8 @@ func (s *UpdateControllerTestSuite) TestStartUpdateOk() {
 	testdoubles.SetTemplateVersions()
 
 	s.T().Run("without parameter", func(t *testing.T) {
-		fxt1 := tf.FillDB(t, s.DB, tf.AddTenants(6), false, tf.AddDefaultNamespaces().State(tenant.Ready).MasterURL("http://api.cluster1"))
-		fxt2 := tf.FillDB(t, s.DB, tf.AddTenants(6), false, tf.AddDefaultNamespaces().State(tenant.Ready).MasterURL("http://api.cluster2"))
+		fxt1 := tf.FillDB(t, s.DB, tf.AddTenants(6), tf.AddDefaultNamespaces().State(tenant.Ready).MasterURL("http://api.cluster1").Outdated())
+		fxt2 := tf.FillDB(t, s.DB, tf.AddTenants(6), tf.AddDefaultNamespaces().State(tenant.Ready).MasterURL("http://api.cluster2").Outdated())
 		configuration.Commit = "124abcd"
 		before := time.Now()
 
@@ -135,8 +135,8 @@ func (s *UpdateControllerTestSuite) TestStartUpdateOk() {
 
 	s.T().Run("with parameters", func(t *testing.T) {
 		updateExecutor.NumberOfCalls = ptr.Uint64(0)
-		fxt1 := tf.FillDB(t, s.DB, tf.AddTenants(6), false, tf.AddDefaultNamespaces().State(tenant.Ready).MasterURL("http://api.cluster1"))
-		fxt2 := tf.FillDB(t, s.DB, tf.AddTenants(6), false, tf.AddDefaultNamespaces().State(tenant.Ready).MasterURL("http://api.cluster2"))
+		fxt1 := tf.FillDB(t, s.DB, tf.AddTenants(6), tf.AddDefaultNamespaces().State(tenant.Ready).MasterURL("http://api.cluster1").Outdated())
+		fxt2 := tf.FillDB(t, s.DB, tf.AddTenants(6), tf.AddDefaultNamespaces().State(tenant.Ready).MasterURL("http://api.cluster2").Outdated())
 		configuration.Commit = "xyz"
 		before := time.Now()
 
@@ -294,7 +294,7 @@ func (s *UpdateControllerTestSuite) TestStopUpdateOk() {
 	defer reset()
 	testdoubles.SetTemplateVersions()
 
-	tf.FillDB(s.T(), s.DB, tf.AddTenants(50), false, tf.AddDefaultNamespaces().State(tenant.Ready))
+	tf.FillDB(s.T(), s.DB, tf.AddTenants(50), tf.AddDefaultNamespaces().State(tenant.Ready).Outdated())
 	configuration.Commit = "124abcd"
 
 	testupdate.Tx(s.T(), s.DB, func(repo update.Repository) error {

--- a/openshift/init_tenant_test.go
+++ b/openshift/init_tenant_test.go
@@ -68,7 +68,7 @@ func (s *InitTenantTestSuite) TestCreateNewNamespacesWithBaseNameEnding2WhenFail
 		gock.OffAll()
 		reset()
 	}()
-	fxt := tf.FillDB(s.T(), s.DB, tf.AddTenantsNamed("johndoe"), true, tf.AddDefaultNamespaces().State(tenant.Provisioning))
+	fxt := tf.FillDB(s.T(), s.DB, tf.AddTenantsNamed("johndoe"), tf.AddDefaultNamespaces().State(tenant.Provisioning))
 	johndoeCalls := 0
 	projectRequestCalls := 0
 	deleteCalls := 0
@@ -131,7 +131,7 @@ func (s *InitTenantTestSuite) TestCreateNewNamespacesWithBaseNameEnding3WhenFail
 		gock.OffAll()
 		reset()
 	}()
-	fxt := tf.FillDB(s.T(), s.DB, tf.AddTenantsNamed("johndoe", "johndoe2"), true, tf.AddDefaultNamespaces().State(tenant.Provisioning))
+	fxt := tf.FillDB(s.T(), s.DB, tf.AddTenantsNamed("johndoe", "johndoe2"), tf.AddDefaultNamespaces().State(tenant.Provisioning))
 
 	gock.New("http://api.cluster1").
 		Post("/api/v1/namespaces/johndoe-jenkins/persistentvolumeclaims").

--- a/tenant/repository_test.go
+++ b/tenant/repository_test.go
@@ -149,7 +149,7 @@ func (s *TenantServiceTestSuite) TestGetAllTenantsToUpdate() {
 		// given
 		configuration.Commit = "123abc"
 		testdoubles.SetTemplateVersions()
-		tf.FillDB(t, s.DB, tf.AddTenants(3), false, tf.AddDefaultNamespaces().State(tenant.Ready))
+		tf.FillDB(t, s.DB, tf.AddTenants(3), tf.AddDefaultNamespaces().State(tenant.Ready).Outdated())
 		svc := tenant.NewDBService(s.DB)
 
 		// when
@@ -164,7 +164,7 @@ func (s *TenantServiceTestSuite) TestGetAllTenantsToUpdate() {
 		// given
 		configuration.Commit = "123abc"
 		testdoubles.SetTemplateVersions()
-		tf.FillDB(t, s.DB, tf.AddTenants(10), false, tf.AddDefaultNamespaces().State(tenant.Ready))
+		tf.FillDB(t, s.DB, tf.AddTenants(10), tf.AddDefaultNamespaces().State(tenant.Ready).Outdated())
 		svc := tenant.NewDBService(s.DB)
 
 		// when
@@ -181,7 +181,7 @@ func (s *TenantServiceTestSuite) TestGetAllTenantsToUpdateBatchByBatch() {
 		// given
 		configuration.Commit = "123abc"
 		testdoubles.SetTemplateVersions()
-		fxt := tf.FillDB(t, s.DB, tf.AddTenants(11), false, tf.AddDefaultNamespaces().State(tenant.Ready))
+		fxt := tf.FillDB(t, s.DB, tf.AddTenants(11), tf.AddDefaultNamespaces().State(tenant.Ready).Outdated())
 		svc := tenant.NewDBService(s.DB)
 		mappedVersions := testdoubles.GetMappedVersions(environment.DefaultEnvTypes...)
 
@@ -264,9 +264,9 @@ func (s *TenantServiceTestSuite) TestGetSubsetOfFailedTenantsToUpdate() {
 		// given
 		testdoubles.SetTemplateVersions()
 		configuration.Commit = "123abc"
-		previouslyFailed := tf.FillDB(t, s.DB, tf.AddTenants(1), false, tf.AddDefaultNamespaces().State(tenant.Failed))
+		previouslyFailed := tf.FillDB(t, s.DB, tf.AddTenants(1), tf.AddDefaultNamespaces().State(tenant.Failed).Outdated())
 		configuration.Commit = "234bcd"
-		tf.FillDB(t, s.DB, tf.AddTenants(6), false, tf.AddDefaultNamespaces().State(tenant.Failed))
+		tf.FillDB(t, s.DB, tf.AddTenants(6), tf.AddDefaultNamespaces().State(tenant.Failed).Outdated())
 
 		svc := tenant.NewDBService(s.DB)
 
@@ -285,8 +285,8 @@ func (s *TenantServiceTestSuite) TestGetSubsetOfTenantsThatAreOutdatedToUpdate()
 		// given
 		testdoubles.SetTemplateVersions()
 		configuration.Commit = "123abc"
-		outdated := tf.FillDB(t, s.DB, tf.AddTenants(1), false, tf.AddDefaultNamespaces().State(tenant.Ready))
-		tf.FillDB(t, s.DB, tf.AddTenants(6), true, tf.AddDefaultNamespaces().State(tenant.Ready))
+		outdated := tf.FillDB(t, s.DB, tf.AddTenants(1), tf.AddDefaultNamespaces().State(tenant.Ready).Outdated())
+		tf.FillDB(t, s.DB, tf.AddTenants(6), tf.AddDefaultNamespaces().State(tenant.Ready))
 
 		svc := tenant.NewDBService(s.DB)
 
@@ -305,10 +305,10 @@ func (s *TenantServiceTestSuite) TestGetSubsetOfTenantsThatMatchesRequiredCluste
 		// given
 		testdoubles.SetTemplateVersions()
 		configuration.Commit = "123abc"
-		toBeFound := tf.FillDB(s.T(), s.DB, tf.AddTenants(1), false,
-			tf.AddDefaultNamespaces().State(tenant.Ready).MasterURL("http://api.cluster1"))
-		tf.FillDB(s.T(), s.DB, tf.AddTenants(3), false,
-			tf.AddDefaultNamespaces().State(tenant.Ready).MasterURL("http://api.cluster2"))
+		toBeFound := tf.FillDB(s.T(), s.DB, tf.AddTenants(1),
+			tf.AddDefaultNamespaces().State(tenant.Ready).MasterURL("http://api.cluster1").Outdated())
+		tf.FillDB(s.T(), s.DB, tf.AddTenants(3),
+			tf.AddDefaultNamespaces().State(tenant.Ready).MasterURL("http://api.cluster2").Outdated())
 
 		svc := tenant.NewDBService(s.DB)
 


### PR DESCRIPTION
before executing the automated tenant update of a particular namespace then it checks whether is outdated or failed.

fixes: #718 