### PR TITLE
issue(#720): make cluster-wide tenants update slower

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -48,6 +48,7 @@ const (
 	varEnvironment                     = "environment"
 	varSentryDSN                       = "sentry.dsn"
 	varAutomatedUpdateRetrySleep       = "automated.update.retry.sleep"
+	varAutomatedUpdateTimeGap          = "automated.update.time.gap"
 	varAutomatedUpdateEnabled          = "automated.update.enabled"
 
 	varAuthURL              = "auth.url"
@@ -145,6 +146,7 @@ func (c *Data) setConfigDefaults() {
 
 	//	Duration how long the automated process should wait to detect other ongoing updates
 	c.v.SetDefault(varAutomatedUpdateRetrySleep, 10*time.Minute)
+	c.v.SetDefault(varAutomatedUpdateTimeGap, 4*time.Second)
 	c.v.SetDefault(varAutomatedUpdateEnabled, false)
 }
 
@@ -341,6 +343,11 @@ func (c *Data) GetSentryDSN() string {
 // GetAutomatedUpdateRetrySleep returns the duration the automated update should wait to detect if there is some other ongoing update
 func (c *Data) GetAutomatedUpdateRetrySleep() time.Duration {
 	return c.v.GetDuration(varAutomatedUpdateRetrySleep)
+}
+
+// GetAutomatedUpdateTimeGap returns the duration the automated update should wait after single tenant update
+func (c *Data) GetAutomatedUpdateTimeGap() time.Duration {
+	return c.v.GetDuration(varAutomatedUpdateTimeGap)
 }
 
 // IsAutomatedUpdateEnabled returns if the automated update is enabled

--- a/controller/update_test.go
+++ b/controller/update_test.go
@@ -349,7 +349,8 @@ func (s *UpdateControllerTestSuite) TestStopUpdateOk() {
 func (s *UpdateControllerTestSuite) newUpdateController(executor *testupdate.DummyUpdateExecutor, timeout time.Duration) (*goa.Service, *controller.UpdateController, func()) {
 	resetEnvs := test.SetEnvironments(
 		test.Env("F8_AUTH_TOKEN_KEY", "foo"),
-		test.Env("F8_AUTOMATED_UPDATE_RETRY_SLEEP", timeout.String()))
+		test.Env("F8_AUTOMATED_UPDATE_RETRY_SLEEP", timeout.String()),
+		test.Env("F8_AUTOMATED_UPDATE_TIME_GAP", "0"))
 	clusterService, _, config, reset := prepareConfigClusterAndAuthService(s.T())
 	svc := goa.New("Tenants-service")
 	return svc, controller.NewUpdateController(svc, s.DB, config, clusterService, executor), func() {

--- a/update/update_minishift_test.go
+++ b/update/update_minishift_test.go
@@ -32,7 +32,8 @@ var numberOfTenants = 11
 
 func TestAutomatedUpdateWithMinishift(t *testing.T) {
 	toReset := test.SetEnvironments(
-		test.Env("F8_AUTOMATED_UPDATE_RETRY_SLEEP", (time.Duration(numberOfTenants) * 8 * time.Second).String()))
+		test.Env("F8_AUTOMATED_UPDATE_RETRY_SLEEP", (time.Duration(numberOfTenants)*8*time.Second).String()),
+		test.Env("F8_AUTOMATED_UPDATE_TIME_GAP", "0"))
 	defer toReset()
 
 	suite.Run(t, &AutomatedUpdateMinishiftTestSuite{

--- a/update/update_test.go
+++ b/update/update_test.go
@@ -442,7 +442,8 @@ func (s *TenantsUpdaterTestSuite) newTenantsUpdater(updateExecutor openshift.Upd
 	filterEnvType update.FilterEnvType, limitToCluster string) (*update.TenantsUpdater, func()) {
 	reset := test.SetEnvironments(
 		test.Env("F8_AUTH_TOKEN_KEY", "foo"),
-		test.Env("F8_AUTOMATED_UPDATE_RETRY_SLEEP", timeout.String()))
+		test.Env("F8_AUTOMATED_UPDATE_RETRY_SLEEP", timeout.String()),
+		test.Env("F8_AUTOMATED_UPDATE_TIME_GAP", "0"))
 
 	saToken, err := test.NewToken(
 		map[string]interface{}{


### PR DESCRIPTION
This PR makes the tenants update slower to avoid capacity issues while running it in prod.
* do not run the tenant updates concurrently
* wait for 4 seconds after a single tenant update

This PR is a result of a discussion with @pbergene

Fixes: #720 