### PR TITLE
feat(#731): return number of outdated tenants

### DIFF
--- a/controller/update.go
+++ b/controller/update.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fabric8-services/fabric8-tenant/environment"
 	"github.com/fabric8-services/fabric8-tenant/jsonapi"
 	"github.com/fabric8-services/fabric8-tenant/openshift"
+	"github.com/fabric8-services/fabric8-tenant/tenant"
 	"github.com/fabric8-services/fabric8-tenant/update"
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
@@ -105,11 +106,33 @@ func (c *UpdateController) Show(ctx *app.ShowUpdateContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, err))
 	}
 
-	updateData := convert(tenantsUpdate)
+	var envTypes = environment.DefaultEnvTypes
+	if value(ctx.EnvType) != "" {
+		envTypes = []environment.Type{environment.Type(value(ctx.EnvType))}
+		if !isOneOfDefaults(envTypes[0]) {
+			return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("env-type", ctx.EnvType))
+		}
+	}
+
+	mappedTemplates := environment.RetrieveMappedTemplates()
+	typesWithVersion := map[environment.Type]string{}
+	for _, envType := range envTypes {
+		typesWithVersion[envType] = mappedTemplates[envType].ConstructCompleteVersion()
+	}
+
+	numberOfOutdated, err := tenant.NewDBService(c.db).GetNumberOfOutdatedTenants(typesWithVersion, configuration.Commit, value(ctx.ClusterURL))
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"err": err,
+		}, "retrieval of number of outdated tenants failed")
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(ctx, err))
+	}
+
+	updateData := convert(tenantsUpdate, numberOfOutdated)
 	return ctx.OK(&app.UpdateDataSingle{Data: updateData})
 }
 
-func convert(tenantsUpdate *update.TenantsUpdate) *app.UpdateData {
+func convert(tenantsUpdate *update.TenantsUpdate, numberOfOutdated int) *app.UpdateData {
 	var fileVersions []*app.FileWithVersion
 	for _, verManager := range update.RetrieveVersionManagers() {
 		fileVersions = append(fileVersions,
@@ -123,6 +146,7 @@ func convert(tenantsUpdate *update.TenantsUpdate) *app.UpdateData {
 		LastTimeUpdated: ptr.Time(tenantsUpdate.LastTimeUpdated),
 		FailedCount:     ptr.Int(tenantsUpdate.FailedCount),
 		FileVersions:    fileVersions,
+		ToUpdate:        &numberOfOutdated,
 	}
 }
 

--- a/design/update.go
+++ b/design/update.go
@@ -17,6 +17,7 @@ var updateData = a.Type("UpdateData", func() {
 	})
 	a.Attribute("file-versions", a.ArrayOf(fileWithVersion), "Lis of files and their versions used for the last finished run", func() {
 	})
+	a.Attribute("to-update", d.Integer, "The number of outdated tenants.")
 	a.Attribute("links", genericLinks)
 })
 
@@ -66,9 +67,16 @@ var _ = a.Resource("update", func() {
 		a.Routing(
 			a.GET(""),
 		)
+		a.Params(func() {
+			a.Param("cluster_url", d.String, "the URL of the OSO cluster the number of outdated tenants should be limited to")
+			a.Param("env_type", d.String, "environment type the number of outdated tenants should be limited to", func() {
+				a.Enum("user", "che", "jenkins", "stage", "run")
+			})
+		})
 
 		a.Description("Get information about last/ongoing update.")
 		a.Response(d.OK, updateInfo)
+		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 	})

--- a/tenant/repository.go
+++ b/tenant/repository.go
@@ -26,6 +26,7 @@ type Service interface {
 	NamespaceExists(nsName string) (bool, error)
 	ExistsWithNsBaseName(nsBaseName string) (bool, error)
 	GetTenantsToUpdate(typeWithVersion map[environment.Type]string, count int, commit string, masterURL string) ([]*Tenant, error)
+	GetNumberOfOutdatedTenants(typeWithVersion map[environment.Type]string, commit string, masterURL string) (int, error)
 }
 
 func NewDBService(db *gorm.DB) Service {
@@ -127,6 +128,19 @@ func (s DBService) GetNamespaces(tenantID uuid.UUID) ([]*Namespace, error) {
 
 func (s DBService) GetTenantsToUpdate(typeWithVersion map[environment.Type]string, count int, commit string, masterURL string) ([]*Tenant, error) {
 	var tenants []*Tenant
+	err := s.createGetOutdatedTenantsQuery(typeWithVersion, commit, masterURL).Limit(count).Scan(&tenants).Error
+
+	return tenants, err
+}
+
+func (s *DBService) GetNumberOfOutdatedTenants(typeWithVersion map[environment.Type]string, commit string, masterURL string) (int, error) {
+	var count int
+	err := s.createGetOutdatedTenantsQuery(typeWithVersion, commit, masterURL).Count(&count).Error
+
+	return count, err
+}
+
+func (s *DBService) createGetOutdatedTenantsQuery(typeWithVersion map[environment.Type]string, commit string, masterURL string) *gorm.DB {
 	nsSubQuery := s.db.Table(Namespace{}.TableName()).Select("tenant_id")
 	nsSubQuery = nsSubQuery.Where("state != 'failed' OR (state = 'failed' AND updated_by != ?)", commit)
 	if masterURL != "" {
@@ -140,12 +154,8 @@ func (s DBService) GetTenantsToUpdate(typeWithVersion map[environment.Type]strin
 		params = append(params, envType, version)
 	}
 	nsSubQuery = nsSubQuery.Where(strings.Join(conditions, " OR "), params...).Group("tenant_id")
-
-	err := s.db.Table(Tenant{}.TableName()).
-		Joins("INNER JOIN ? n ON tenants.id = n.tenant_id", nsSubQuery.SubQuery()).Limit(count).
-		Scan(&tenants).Error
-
-	return tenants, err
+	return s.db.Table(Tenant{}.TableName()).
+		Joins("INNER JOIN ? n ON tenants.id = n.tenant_id", nsSubQuery.SubQuery())
 }
 
 func (s DBService) DeleteNamespaces(tenantID uuid.UUID) error {

--- a/tenant/repository.go
+++ b/tenant/repository.go
@@ -128,19 +128,19 @@ func (s DBService) GetNamespaces(tenantID uuid.UUID) ([]*Namespace, error) {
 
 func (s DBService) GetTenantsToUpdate(typeWithVersion map[environment.Type]string, count int, commit string, masterURL string) ([]*Tenant, error) {
 	var tenants []*Tenant
-	err := s.createGetOutdatedTenantsQuery(typeWithVersion, commit, masterURL).Limit(count).Scan(&tenants).Error
+	err := s.newGetOutdatedTenantsQuery(typeWithVersion, commit, masterURL).Limit(count).Scan(&tenants).Error
 
 	return tenants, err
 }
 
 func (s *DBService) GetNumberOfOutdatedTenants(typeWithVersion map[environment.Type]string, commit string, masterURL string) (int, error) {
 	var count int
-	err := s.createGetOutdatedTenantsQuery(typeWithVersion, commit, masterURL).Count(&count).Error
+	err := s.newGetOutdatedTenantsQuery(typeWithVersion, commit, masterURL).Count(&count).Error
 
 	return count, err
 }
 
-func (s *DBService) createGetOutdatedTenantsQuery(typeWithVersion map[environment.Type]string, commit string, masterURL string) *gorm.DB {
+func (s *DBService) newGetOutdatedTenantsQuery(typeWithVersion map[environment.Type]string, commit string, masterURL string) *gorm.DB {
 	nsSubQuery := s.db.Table(Namespace{}.TableName()).Select("tenant_id")
 	nsSubQuery = nsSubQuery.Where("state != 'failed' OR (state = 'failed' AND updated_by != ?)", commit)
 	if masterURL != "" {


### PR DESCRIPTION
When GET to `api/update` is called, then the response (apart from the information about an ongoing update) contains also a number of outdated tenants (that are going to be updated) `to-update`. 
It supports limitation to both env type and master URL.

Fixes: #731 