### PR TITLE
when checks for presence of namespaces then 403 treat as it is not present

### DIFF
--- a/openshift/callback.go
+++ b/openshift/callback.go
@@ -109,7 +109,7 @@ var FailIfAlreadyExists = BeforeDoCallback{
 
 		result, err := objEndpoints.Apply(client, object, http.MethodGet)
 		if err != nil {
-			if result != nil && result.response.StatusCode == http.StatusNotFound {
+			if result != nil && (result.response.StatusCode == http.StatusNotFound || result.response.StatusCode == http.StatusForbidden) {
 				bodyToSend, err := yaml.Marshal(object)
 				if err != nil {
 					return nil, nil, errors.Wrapf(err, "unable marshal object to be send to OS as part of %s request", method.action)

--- a/openshift/callback_test.go
+++ b/openshift/callback_test.go
@@ -517,6 +517,23 @@ func TestFailIfAlreadyExists(t *testing.T) {
 		assert.Equal(t, methodDefinition, actualMethodDef)
 		assert.Contains(t, string(body), "name: john-jenkins")
 	})
+
+	t.Run("when returns 403, then it should return original method and body", func(t *testing.T) {
+		// given
+		defer gock.OffAll()
+		gock.New("https://starter.com").
+			Get("/oapi/v1/projects/john-jenkins").
+			Reply(403).
+			BodyString(``)
+
+		// when
+		actualMethodDef, body, err := openshift.FailIfAlreadyExists.Call(client, object, endpoints, methodDefinition)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, methodDefinition, actualMethodDef)
+		assert.Contains(t, string(body), "name: john-jenkins")
+	})
 }
 
 func getClientObjectEndpointAndMethod(t *testing.T, method, kind, response string) (*openshift.Client, environment.Object, *openshift.ObjectEndpoints, *openshift.MethodDefinition) {


### PR DESCRIPTION
when tenant checks for the presence of namespaces (before their creation) then it treats 403 as not present because OS returns 403 for projects that are not present