### PR TITLE
fix: for checking if ns was created use same token as for creation

### DIFF
--- a/openshift/callback.go
+++ b/openshift/callback.go
@@ -107,7 +107,12 @@ func getMethodAndMarshalObject(objEndpoints *ObjectEndpoints, method string, obj
 var FailIfAlreadyExists = BeforeDoCallback{
 	Call: func(client *Client, object environment.Object, objEndpoints *ObjectEndpoints, method *MethodDefinition) (*MethodDefinition, []byte, error) {
 
-		result, err := objEndpoints.Apply(client, object, http.MethodGet)
+		masterClient := *client
+		masterClient.TokenProducer = func(forceMasterToken bool) string {
+			return client.TokenProducer(true)
+		}
+
+		result, err := objEndpoints.Apply(&masterClient, object, http.MethodGet)
 		if err != nil {
 			if result != nil && (result.response.StatusCode == http.StatusNotFound || result.response.StatusCode == http.StatusForbidden) {
 				bodyToSend, err := yaml.Marshal(object)

--- a/openshift/endpoints.go
+++ b/openshift/endpoints.go
@@ -17,15 +17,15 @@ var (
 	AllObjectEndpoints = map[string]*ObjectEndpoints{
 		environment.ValKindNamespace: endpoints(
 			endpoint(`/api/v1/namespaces`, POST(BeforeDo(FailIfAlreadyExists), AfterDo(GetObject))),
-			endpoint(`/api/v1/namespaces/{{ index . "metadata" "name"}}`, PATCH(), GET(Require(MasterToken)), DELETE())),
+			endpoint(`/api/v1/namespaces/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 
 		environment.ValKindProject: endpoints(
 			endpoint(`/oapi/v1/projects`, POST(BeforeDo(FailIfAlreadyExists), AfterDo(GetObject))),
-			endpoint(`/oapi/v1/projects/{{ index . "metadata" "name"}}`, PATCH(), GET(Require(MasterToken)), DELETE())),
+			endpoint(`/oapi/v1/projects/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 
 		environment.ValKindProjectRequest: endpoints(
 			endpoint(`/oapi/v1/projectrequests`, POST(BeforeDo(FailIfAlreadyExists), AfterDo(GetObject))),
-			endpoint(`/oapi/v1/projects/{{ index . "metadata" "name"}}`, PATCH(), GET(Require(MasterToken)), DELETE())),
+			endpoint(`/oapi/v1/projects/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 
 		environment.ValKindRole: endpoints(
 			endpoint(`/oapi/v1/namespaces/{{ index . "metadata" "namespace"}}/roles`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),

--- a/test/gock_matchers.go
+++ b/test/gock_matchers.go
@@ -45,6 +45,16 @@ func createReqMatcher(matchers []gock.MatchFunc) gock.Matcher {
 	return matcher
 }
 
+func HasBearerWithSub(sub string) gock.MatchFunc {
+	return func(req *http.Request, gockReq *gock.Request) (bool, error) {
+		authHeader, ok := req.Header["Authorization"]
+		if ok && len(authHeader) == 1 && strings.HasPrefix(authHeader[0], "Bearer ") {
+			return authHeader[0][7:] == sub, nil
+		}
+		return false, nil
+	}
+}
+
 func HasJWTWithSub(sub string) gock.MatchFunc {
 	return func(req *http.Request, gockReq *gock.Request) (bool, error) {
 		// look-up the JWT's "sub" claim and compare with the request


### PR DESCRIPTION
when tenant checks that namespace was created, it should use the same token as was used for creation