### PR TITLE
 fix: handle correctly conflicts for resource quotas 

### DIFF
--- a/openshift/callback.go
+++ b/openshift/callback.go
@@ -166,7 +166,7 @@ func removeAfterDoCallback(method MethodDefinition, callbackName string) *Method
 			break
 		}
 	}
-	return withoutCallback
+	return &withoutCallback
 }
 
 var WhenConflictThenFail = AfterDoCallback{

--- a/openshift/callback_test.go
+++ b/openshift/callback_test.go
@@ -164,7 +164,7 @@ func TestGetMissingObjectAndMerge(t *testing.T) {
 	assert.NoError(t, err)
 	postMethodDef, err := endpoints.GetMethodDefinition("POST", object)
 	assert.NoError(t, err)
-	assert.Equal(t, postMethodDef, methodDef)
+	assert.Equal(t, fmt.Sprintf("%+v", *postMethodDef), fmt.Sprintf("%+v", *methodDef))
 	var actualObject environment.Object
 	assert.NoError(t, yaml.Unmarshal(body, &actualObject))
 	assert.Equal(t, object, actualObject)

--- a/openshift/endpoints.go
+++ b/openshift/endpoints.go
@@ -73,7 +73,7 @@ var (
 			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/configmaps/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 
 		environment.ValKindResourceQuota: endpoints(
-			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/resourcequotas`, POST(AfterDo(WhenConflictThenDeleteAndRedo), AfterDo(GetObject))),
+			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/resourcequotas`, POST(AfterDo(WhenConflictThenDeleteAndRedo, GetObject))),
 			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/resourcequotas/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 
 		environment.ValKindLimitRange: endpoints(

--- a/openshift/endpoints.go
+++ b/openshift/endpoints.go
@@ -10,7 +10,7 @@ import (
 // ObjectEndpoints is list of MethodDefinitions for a particular object endpoint (eg. `/oapi/v1/projectrequests`).
 // In other words, is saying which methods (Post/Delete/Get/Patch) are allowed to be performed for the endpoint
 type ObjectEndpoints struct {
-	Methods map[string]*MethodDefinition
+	Methods map[string]MethodDefinition
 }
 
 var (
@@ -95,8 +95,8 @@ metadata:
   name: admin`
 )
 
-func endpoint(endpoint string, methodsDefCreators ...methodDefCreator) func(methods map[string]*MethodDefinition) {
-	return func(methods map[string]*MethodDefinition) {
+func endpoint(endpoint string, methodsDefCreators ...methodDefCreator) func(methods map[string]MethodDefinition) {
+	return func(methods map[string]MethodDefinition) {
 		for _, methodDefCreator := range methodsDefCreators {
 			methodDef := methodDefCreator(endpoint)
 			methods[methodDef.action] = methodDef
@@ -104,8 +104,8 @@ func endpoint(endpoint string, methodsDefCreators ...methodDefCreator) func(meth
 	}
 }
 
-func endpoints(endpoints ...func(methods map[string]*MethodDefinition)) *ObjectEndpoints {
-	methods := make(map[string]*MethodDefinition)
+func endpoints(endpoints ...func(methods map[string]MethodDefinition)) *ObjectEndpoints {
+	methods := make(map[string]MethodDefinition)
 	for _, endpoint := range endpoints {
 		endpoint(methods)
 	}
@@ -182,7 +182,7 @@ func (e *ObjectEndpoints) GetMethodDefinition(method string, object environment.
 	if !found {
 		return nil, fmt.Errorf("method definition %s for %s not supported", method, environment.GetKind(object))
 	}
-	return methodDef, nil
+	return &methodDef, nil
 }
 
 func logParams(object environment.Object, method *MethodDefinition, result *Result) map[string]interface{} {

--- a/openshift/methods.go
+++ b/openshift/methods.go
@@ -12,20 +12,20 @@ type MethodDefinition struct {
 	requestCreator    RequestCreator
 }
 
-func NewMethodDefinition(action string, beforeCallbacks []BeforeDoCallback, afterCallbacks []AfterDoCallback, requestCreator RequestCreator, modifiers ...MethodDefModifier) *MethodDefinition {
-	methodDefinition := &MethodDefinition{
+func NewMethodDefinition(action string, beforeCallbacks []BeforeDoCallback, afterCallbacks []AfterDoCallback, requestCreator RequestCreator, modifiers ...MethodDefModifier) MethodDefinition {
+	methodDefinition := MethodDefinition{
 		action:            action,
 		beforeDoCallbacks: beforeCallbacks,
 		afterDoCallbacks:  afterCallbacks,
 		requestCreator:    requestCreator,
 	}
 	for _, modify := range modifiers {
-		modify(methodDefinition)
+		modify(&methodDefinition)
 	}
 	return methodDefinition
 }
 
-type methodDefCreator func(endpoint string) *MethodDefinition
+type methodDefCreator func(endpoint string) MethodDefinition
 type RequestCreatorModifier func(requestCreator RequestCreator) RequestCreator
 
 type MethodDefModifier func(*MethodDefinition) *MethodDefinition
@@ -56,7 +56,7 @@ func MasterToken(requestCreator RequestCreator) RequestCreator {
 }
 
 func POST(modifiers ...MethodDefModifier) methodDefCreator {
-	return func(urlTemplate string) *MethodDefinition {
+	return func(urlTemplate string) MethodDefinition {
 		return NewMethodDefinition(
 			http.MethodPost,
 			[]BeforeDoCallback{},
@@ -69,7 +69,7 @@ func POST(modifiers ...MethodDefModifier) methodDefCreator {
 	}
 }
 func PATCH(modifiers ...MethodDefModifier) methodDefCreator {
-	return func(urlTemplate string) *MethodDefinition {
+	return func(urlTemplate string) MethodDefinition {
 		return NewMethodDefinition(
 			http.MethodPatch,
 			[]BeforeDoCallback{GetObjectAndMerge},
@@ -87,7 +87,7 @@ func PATCH(modifiers ...MethodDefModifier) methodDefCreator {
 	}
 }
 func GET(modifiers ...MethodDefModifier) methodDefCreator {
-	return func(urlTemplate string) *MethodDefinition {
+	return func(urlTemplate string) MethodDefinition {
 		return NewMethodDefinition(
 			http.MethodGet,
 			[]BeforeDoCallback{},
@@ -101,7 +101,7 @@ func GET(modifiers ...MethodDefModifier) methodDefCreator {
 }
 
 func DELETE(modifiers ...MethodDefModifier) methodDefCreator {
-	return func(urlTemplate string) *MethodDefinition {
+	return func(urlTemplate string) MethodDefinition {
 		return NewMethodDefinition(
 			http.MethodDelete,
 			[]BeforeDoCallback{},


### PR DESCRIPTION
handle correctly conflicts for resource quotas (mainly the part of removing `afterdocallback`) otherwise it doesn't redo and just fails