### PR TITLE
fix: wait until PVC is removed or set to terminating state

### DIFF
--- a/openshift/endpoints.go
+++ b/openshift/endpoints.go
@@ -54,7 +54,8 @@ var (
 
 		environment.ValKindPersistenceVolumeClaim: endpoints(
 			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/persistentvolumeclaims`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
-			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/persistentvolumeclaims/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/persistentvolumeclaims/{{ index . "metadata" "name"}}`,
+				PATCH(), GET(), DELETE(AfterDo(WaitUntilIsGone)))),
 
 		environment.ValKindService: endpoints(
 			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/services`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),

--- a/test/doubles/test_doubles.go
+++ b/test/doubles/test_doubles.go
@@ -239,6 +239,13 @@ func MockCleanRequestsToOS(calls *int, cluster string) {
 		Persist().
 		Reply(200).
 		BodyString("{}")
+	gock.New(cluster).
+		Get("").
+		SetMatcher(test.ExpectRequest(
+			test.HasUrlMatching(`.*\/(persistentvolumeclaims)\/.*`),
+			test.SpyOnCallsMatchFunc(calls))).
+		Persist().
+		Reply(404)
 }
 
 func MockRemoveRequestsToOS(calls *int, cluster string) {
@@ -260,7 +267,7 @@ func ExpectedNumberOfCallsWhenPost(t *testing.T, config *configuration.Data) int
 
 func ExpectedNumberOfCallsWhenClean(t *testing.T, config *configuration.Data, envTypes ...environment.Type) int {
 	objectsInTemplates := RetrieveObjects(t, config, DefaultClusterMapping, DefaultUserInfo, envTypes...)
-	return NumberOfObjectsToClean(objectsInTemplates)
+	return NumberOfObjectsToClean(objectsInTemplates) + CountObjectsThat(objectsInTemplates, isOfKind(environment.ValKindPersistenceVolumeClaim))
 }
 
 func ExpectedNumberOfCallsWhenPatch(t *testing.T, config *configuration.Data, envTypes ...environment.Type) int {


### PR DESCRIPTION
wait until PVC is removed or set to terminating state otherwise the following POST request doesn't detect that should be in terminating state but the state hasn't been set to that because the tenant service is too fast and OS is too slow 