### PR TITLE
fix: reset result when either 404 or 409 is ignored

### DIFF
--- a/openshift/callback.go
+++ b/openshift/callback.go
@@ -138,8 +138,8 @@ var WhenConflictThenDeleteAndRedo = AfterDoCallback{
 			//	"method": method.action,
 			//	"object": object,
 			//}, "there was a conflict, trying to delete the object and re-do the operation")
-			fmt.Println(fmt.Sprintf("WARNING: there was a conflict when doing %s on object %s, trying to delete the object and re-do the operation",
-				method.action, object.ToString()))
+			fmt.Println(fmt.Sprintf("WARNING: there was a conflict when doing %s on object %s/%s, trying to delete the object and re-do the operation",
+				method.action, environment.GetKind(object), environment.GetName(object)))
 			err := checkHTTPCode(objEndpoints.Apply(client, object, http.MethodDelete))
 			if err != nil {
 				return errors.Wrap(err, "delete request failed while removing an object because of a conflict")
@@ -226,8 +226,12 @@ var IgnoreWhenDoesNotExistOrConflicts = AfterDoCallback{
 			//	"object":  object.ToString(),
 			//	"message": result.Body,
 			//}, "failed to %s the object. Ignoring this error because it probably does not exist or is being removed", method.action)
-			fmt.Println(fmt.Sprintf("WARNING: failed to %s the object %s - reveived response %s. "+
-				"Ignoring this error because it probably does not exist or is being removed", method.action, object.ToString(), result.response.Status))
+			fmt.Println(fmt.Sprintf("WARNING: failed to %s the object %s/%s - reveived response %s. "+
+				"Ignoring this error because it probably does not exist or is being removed",
+				method.action, environment.GetKind(object), environment.GetName(object), result.response.Status))
+			result.err = nil
+			result.Body = []byte{}
+			result.response = nil
 			return nil
 		}
 		return checkHTTPCode(result, result.err)
@@ -270,9 +274,9 @@ var TryToWaitUntilIsGone = AfterDoCallback{
 			//	"cluster":       client.MasterURL,
 			//	"error-message": msg,
 			//}, "unable to finish the action %s for an object as there were %d of unsuccessful retries to completely remove the objects from the cluster", method.action)
-			fmt.Println(fmt.Sprintf("WARNING: unable to finish the action %s for an object %s as there were %d of unsuccessful retries "+
+			fmt.Println(fmt.Sprintf("WARNING: unable to finish the action %s for an object %s/%s as there were %d of unsuccessful retries "+
 				"to completely remove the objects from the cluster %s. The retrieved errors:%s",
-				method.action, object, retries, client.MasterURL, msg))
+				method.action, environment.GetKind(object), environment.GetName(object), retries, client.MasterURL, msg))
 		}
 		return nil
 	},

--- a/openshift/callback_test.go
+++ b/openshift/callback_test.go
@@ -252,10 +252,7 @@ func TestWhenConflictThenDeleteAndRedoAction(t *testing.T) {
 		defer gock.OffAll()
 		gock.New("https://starter.com").
 			Delete("/api/v1/namespaces/john-jenkins/persistentvolumeclaims/jenkins-home").
-			Reply(404)
-		gock.New("https://starter.com").
-			Get("/api/v1/namespaces/john-jenkins/persistentvolumeclaims/jenkins-home").
-			Reply(404)
+			Reply(500)
 		result := openshift.NewResult(&http.Response{StatusCode: http.StatusConflict}, []byte{}, nil)
 
 		// when
@@ -264,7 +261,7 @@ func TestWhenConflictThenDeleteAndRedoAction(t *testing.T) {
 		// then
 		test.AssertError(t, err,
 			test.HasMessageContaining("delete request failed while removing an object because of a conflict"),
-			test.HasMessageContaining("server responded with status: 404 for the DELETE request"))
+			test.HasMessageContaining("server responded with status: 500 for the DELETE request"))
 	})
 
 	t.Run("when there is a second conflict while redoing the action, then it return an error and stops redoing", func(t *testing.T) {
@@ -305,6 +302,7 @@ func TestIgnoreWhenDoesNotExist(t *testing.T) {
 
 		// then
 		assert.NoError(t, err)
+		assert.Empty(t, result.Body)
 	})
 
 	t.Run("when there is 409, then it ignores it even if there is an error", func(t *testing.T) {


### PR DESCRIPTION
reset result when either 404 or 409 is ignored to not be checked in followings callbacks
make printing of the warnings shorter