### PR TITLE
fix: clean should delete all resources (not only those that are in templates)

### DIFF
--- a/environment/template.go
+++ b/environment/template.go
@@ -13,42 +13,48 @@ import (
 )
 
 const (
-	FieldKind            = "kind"
-	FieldAPIVersion      = "apiVersion"
-	FieldObjects         = "objects"
-	FieldSpec            = "spec"
-	FieldTemplate        = "templateDef"
-	FieldItems           = "items"
-	FieldMetadata        = "metadata"
-	FieldLabels          = "labels"
-	FieldReplicas        = "replicas"
-	FieldVersion         = "version"
-	FieldVersionQuotas   = "version-quotas"
-	FieldNamespace       = "namespace"
-	FieldName            = "name"
-	FieldStatus          = "status"
-	FieldResourceVersion = "resourceVersion"
-	FieldParameters      = "parameters"
+	FieldKind          = "kind"
+	FieldObjects       = "objects"
+	FieldSpec          = "spec"
+	FieldItems         = "items"
+	FieldMetadata      = "metadata"
+	FieldLabels        = "labels"
+	FieldVersion       = "version"
+	FieldVersionQuotas = "version-quotas"
+	FieldNamespace     = "namespace"
+	FieldName          = "name"
+	FieldStatus        = "status"
+	FieldParameters    = "parameters"
 
-	ValKindTemplate               = "Template"
-	ValKindNamespace              = "Namespace"
-	ValKindConfigMap              = "ConfigMap"
-	ValKindLimitRange             = "LimitRange"
-	ValKindProject                = "Project"
-	ValKindProjectRequest         = "ProjectRequest"
-	ValKindPersistenceVolumeClaim = "PersistentVolumeClaim"
-	ValKindService                = "Service"
-	ValKindSecret                 = "Secret"
-	ValKindServiceAccount         = "ServiceAccount"
-	ValKindRoleBindingRestriction = "RoleBindingRestriction"
-	ValKindRoleBinding            = "RoleBinding"
-	ValKindRole                   = "Role"
-	ValKindRoute                  = "Route"
-	ValKindJob                    = "Job"
-	ValKindList                   = "List"
-	ValKindDeployment             = "Deployment"
-	ValKindDeploymentConfig       = "DeploymentConfig"
-	ValKindResourceQuota          = "ResourceQuota"
+	ValKindTemplate                = "Template"
+	ValKindNamespace               = "Namespace"
+	ValKindConfigMap               = "ConfigMap"
+	ValKindLimitRange              = "LimitRange"
+	ValKindProject                 = "Project"
+	ValKindProjectRequest          = "ProjectRequest"
+	ValKindPersistentVolumeClaim   = "PersistentVolumeClaim"
+	ValKindService                 = "Service"
+	ValKindSecret                  = "Secret"
+	ValKindServiceAccount          = "ServiceAccount"
+	ValKindRoleBindingRestriction  = "RoleBindingRestriction"
+	ValKindRoleBinding             = "RoleBinding"
+	ValKindRole                    = "Role"
+	ValKindRoute                   = "Route"
+	ValKindJob                     = "Job"
+	ValKindList                    = "List"
+	ValKindDeployment              = "Deployment"
+	ValKindDeploymentConfig        = "DeploymentConfig"
+	ValKindResourceQuota           = "ResourceQuota"
+	ValKindPod                     = "Pod"
+	ValKindReplicationController   = "ReplicationController"
+	ValKindDaemonSet               = "DaemonSet"
+	ValKindReplicaSet              = "ReplicaSet"
+	ValKindStatefulSet             = "StatefulSet"
+	ValKindHorizontalPodAutoScaler = "HorizontalPodAutoScaler"
+	ValKindCronJob                 = "CronJob"
+	ValKindBuildConfig             = "BuildConfig"
+	ValKindBuild                   = "Build"
+	ValKindImageStream             = "ImageStream"
 
 	varUserName              = "USER_NAME"
 	varProjectUser           = "PROJECT_USER"
@@ -63,21 +69,32 @@ const (
 )
 
 var sortOrder = map[string]int{
-	"Namespace":              1,
-	"ProjectRequest":         1,
-	"Role":                   2,
-	"RoleBindingRestriction": 3,
-	"LimitRange":             4,
-	"ResourceQuota":          5,
-	"Secret":                 6,
-	"ServiceAccount":         7,
-	"Service":                8,
-	"RoleBinding":            9,
-	"PersistentVolumeClaim":  10,
-	"ConfigMap":              11,
-	"DeploymentConfig":       12,
-	"Route":                  13,
-	"Job":                    14,
+	ValKindNamespace:               1,
+	ValKindProjectRequest:          1,
+	ValKindRole:                    2,
+	ValKindRoleBindingRestriction:  3,
+	ValKindLimitRange:              4,
+	ValKindResourceQuota:           5,
+	ValKindSecret:                  6,
+	ValKindServiceAccount:          7,
+	ValKindService:                 8,
+	ValKindRoleBinding:             9,
+	ValKindPersistentVolumeClaim:   10,
+	ValKindConfigMap:               11,
+	ValKindDeploymentConfig:        12,
+	ValKindRoute:                   13,
+	ValKindJob:                     14,
+	ValKindPod:                     15,
+	ValKindReplicationController:   15,
+	ValKindDaemonSet:               15,
+	ValKindDeployment:              15,
+	ValKindReplicaSet:              15,
+	ValKindStatefulSet:             15,
+	ValKindHorizontalPodAutoScaler: 15,
+	ValKindCronJob:                 15,
+	ValKindBuildConfig:             15,
+	ValKindBuild:                   15,
+	ValKindImageStream:             15,
 }
 
 type Objects []Object

--- a/openshift/callback_test.go
+++ b/openshift/callback_test.go
@@ -97,7 +97,7 @@ var tokenProducer = func(forceMasterToken bool) string {
 func TestGetExistingObjectAndMerge(t *testing.T) {
 	// given
 	defer gock.OffAll()
-	client, object, endpoints, methodDefinition := getClientObjectEndpointAndMethod(t, "PATCH", environment.ValKindPersistenceVolumeClaim, pvcToSet)
+	client, object, endpoints, methodDefinition := getClientObjectEndpointAndMethod(t, "PATCH", environment.ValKindPersistentVolumeClaim, pvcToSet)
 
 	gock.New("https://starter.com").
 		Get("/api/v1/namespaces/john-jenkins/persistentvolumeclaims/jenkins-home").
@@ -119,7 +119,7 @@ func TestGetExistingObjectAndMerge(t *testing.T) {
 func TestGetExistingObjectAndWaitTillIsNotTerminating(t *testing.T) {
 	// given
 	defer gock.OffAll()
-	client, object, endpoints, methodDefinition := getClientObjectEndpointAndMethod(t, "PATCH", environment.ValKindPersistenceVolumeClaim, pvcToSet)
+	client, object, endpoints, methodDefinition := getClientObjectEndpointAndMethod(t, "PATCH", environment.ValKindPersistentVolumeClaim, pvcToSet)
 
 	terminatingCalls := 0
 	gock.New("https://starter.com").
@@ -151,7 +151,7 @@ func TestGetExistingObjectAndWaitTillIsNotTerminating(t *testing.T) {
 func TestGetMissingObjectAndMerge(t *testing.T) {
 	// given
 	defer gock.OffAll()
-	client, object, endpoints, methodDefinition := getClientObjectEndpointAndMethod(t, "PATCH", environment.ValKindPersistenceVolumeClaim, pvcToSet)
+	client, object, endpoints, methodDefinition := getClientObjectEndpointAndMethod(t, "PATCH", environment.ValKindPersistentVolumeClaim, pvcToSet)
 
 	gock.New("https://starter.com").
 		Get("/api/v1/namespaces/john-jenkins/persistentvolumeclaims/jenkins-home").
@@ -172,7 +172,7 @@ func TestGetMissingObjectAndMerge(t *testing.T) {
 
 func TestWhenNoConflictThenJustCheckResponseCode(t *testing.T) {
 	// given
-	client, object, endpoints, methodDefinition := getClientObjectEndpointAndMethod(t, "POST", environment.ValKindPersistenceVolumeClaim, pvcToSet)
+	client, object, endpoints, methodDefinition := getClientObjectEndpointAndMethod(t, "POST", environment.ValKindPersistentVolumeClaim, pvcToSet)
 
 	t.Run("original response is 200 and error is nil, so no error is returned", func(t *testing.T) {
 		// given
@@ -223,7 +223,7 @@ func TestWhenNoConflictThenJustCheckResponseCode(t *testing.T) {
 
 func TestWhenConflictThenDeleteAndRedoAction(t *testing.T) {
 	// given
-	client, object, endpoints, methodDefinition := getClientObjectEndpointAndMethod(t, "POST", environment.ValKindPersistenceVolumeClaim, pvcToSet)
+	client, object, endpoints, methodDefinition := getClientObjectEndpointAndMethod(t, "POST", environment.ValKindPersistentVolumeClaim, pvcToSet)
 
 	t.Run("both delete and redo post is successful", func(t *testing.T) {
 		// given
@@ -291,7 +291,7 @@ func TestWhenConflictThenDeleteAndRedoAction(t *testing.T) {
 
 func TestIgnoreWhenDoesNotExist(t *testing.T) {
 	// given
-	client, object, endpoints, methodDefinition := getClientObjectEndpointAndMethod(t, "DELETE", environment.ValKindPersistenceVolumeClaim, pvcToSet)
+	client, object, endpoints, methodDefinition := getClientObjectEndpointAndMethod(t, "DELETE", environment.ValKindPersistentVolumeClaim, pvcToSet)
 
 	t.Run("when there is 404, then it ignores it even if there is an error", func(t *testing.T) {
 		// given
@@ -368,7 +368,7 @@ func TestIgnoreWhenDoesNotExist(t *testing.T) {
 
 func TestGetObject(t *testing.T) {
 	// given
-	client, object, endpoints, methodDefinition := getClientObjectEndpointAndMethod(t, "POST", environment.ValKindPersistenceVolumeClaim, pvcToSet)
+	client, object, endpoints, methodDefinition := getClientObjectEndpointAndMethod(t, "POST", environment.ValKindPersistentVolumeClaim, pvcToSet)
 
 	t.Run("when returns 200, then it reads the object an checks status. everything is good, then return nil", func(t *testing.T) {
 		// given
@@ -604,7 +604,7 @@ func TestFailIfAlreadyExistsForUserNamespaceShouldUseMasterToken(t *testing.T) {
 
 func TestWaitUntilIsGone(t *testing.T) {
 	// given
-	client, object, endpoints, methodDefinition := getClientObjectEndpointAndMethod(t, "DELETE", environment.ValKindPersistenceVolumeClaim, pvcToSet)
+	client, object, endpoints, methodDefinition := getClientObjectEndpointAndMethod(t, "DELETE", environment.ValKindPersistentVolumeClaim, pvcToSet)
 	result := openshift.NewResult(&http.Response{StatusCode: http.StatusOK}, []byte{}, nil)
 
 	t.Run("wait until is in terminating state", func(t *testing.T) {

--- a/openshift/endpoints.go
+++ b/openshift/endpoints.go
@@ -41,19 +41,21 @@ var (
 				PATCH(Require(MasterToken)), GET(Require(MasterToken)), DELETE(Require(MasterToken)))),
 
 		environment.ValKindRoute: endpoints(
-			endpoint(`/oapi/v1/namespaces/{{ index . "metadata" "namespace"}}/routes`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
+			endpoint(`/oapi/v1/namespaces/{{ index . "metadata" "namespace"}}/routes`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
 			endpoint(`/oapi/v1/namespaces/{{ index . "metadata" "namespace"}}/routes/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 
 		environment.ValKindDeployment: endpoints(
-			endpoint(`/apis/extensions/v1beta1/namespaces/{{ index . "metadata" "namespace"}}/deployments`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
-			endpoint(`/apis/extensions/v1beta1/namespaces/{{ index . "metadata" "namespace"}}/deployments/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/deployments`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/deployments/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 
 		environment.ValKindDeploymentConfig: endpoints(
-			endpoint(`/apis/apps.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/deploymentconfigs`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
-			endpoint(`/apis/apps.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/deploymentconfigs/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+			endpoint(`/apis/apps.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/deploymentconfigs`,
+				POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/apis/apps.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/deploymentconfigs/{{ index . "metadata" "name"}}`,
+				PATCH(), GET(), DELETE())),
 
-		environment.ValKindPersistenceVolumeClaim: endpoints(
-			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/persistentvolumeclaims`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
+		environment.ValKindPersistentVolumeClaim: endpoints(
+			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/persistentvolumeclaims`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
 			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/persistentvolumeclaims/{{ index . "metadata" "name"}}`,
 				PATCH(), GET(), DELETE(AfterDo(TryToWaitUntilIsGone)))),
 
@@ -70,7 +72,7 @@ var (
 			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/serviceaccounts/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 
 		environment.ValKindConfigMap: endpoints(
-			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/configmaps`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
+			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/configmaps`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
 			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/configmaps/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 
 		environment.ValKindResourceQuota: endpoints(
@@ -82,8 +84,48 @@ var (
 			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/limitranges/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 
 		environment.ValKindJob: endpoints(
-			endpoint(`/apis/batch/v1/namespaces/{{ index . "metadata" "namespace"}}/jobs`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
+			endpoint(`/apis/batch/v1/namespaces/{{ index . "metadata" "namespace"}}/jobs`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
 			endpoint(`/apis/batch/v1/namespaces/{{ index . "metadata" "namespace"}}/jobs/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+
+		environment.ValKindPod: endpoints(
+			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/pods`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/pods/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+
+		environment.ValKindReplicationController: endpoints(
+			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/replicationcontrollers`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/replicationcontrollers/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+
+		environment.ValKindDaemonSet: endpoints(
+			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/daemonsets`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/daemonsets/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+
+		environment.ValKindReplicaSet: endpoints(
+			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/replicasets`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/replicasets/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+
+		environment.ValKindStatefulSet: endpoints(
+			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/statefulsets`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/statefulsets/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+
+		environment.ValKindHorizontalPodAutoScaler: endpoints(
+			endpoint(`/apis/autoscaling/v1/namespaces/{{ index . "metadata" "namespace"}}/horizontalpodautoscalers`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/apis/autoscaling/v1/namespaces/{{ index . "metadata" "namespace"}}/horizontalpodautoscalers/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+
+		environment.ValKindCronJob: endpoints(
+			endpoint(`/apis/batch/v1beta1/namespaces/{{ index . "metadata" "namespace"}}/cronjobs`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/apis/batch/v1beta1/namespaces/{{ index . "metadata" "namespace"}}/cronjobs/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+
+		environment.ValKindBuildConfig: endpoints(
+			endpoint(`/apis/build.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/buildconfigs`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/apis/build.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/buildconfigs/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+
+		environment.ValKindBuild: endpoints(
+			endpoint(`/apis/build.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/builds`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/apis/build.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/builds/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+
+		environment.ValKindImageStream: endpoints(
+			endpoint(`/apis/image.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/imagestreams`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/apis/image.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/imagestreams/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 	}
 	deleteOptions = `apiVersion: v1
 kind: DeleteOptions

--- a/openshift/methods.go
+++ b/openshift/methods.go
@@ -30,6 +30,8 @@ type RequestCreatorModifier func(requestCreator RequestCreator) RequestCreator
 
 type MethodDefModifier func(*MethodDefinition) *MethodDefinition
 
+const MethodDeleteAll = "DELETEALL"
+
 func BeforeDo(beforeDoCallback ...BeforeDoCallback) MethodDefModifier {
 	return func(methodDefinition *MethodDefinition) *MethodDefinition {
 		methodDefinition.beforeDoCallbacks = append(methodDefinition.beforeDoCallbacks, beforeDoCallback...)
@@ -104,6 +106,21 @@ func DELETE(modifiers ...MethodDefModifier) methodDefCreator {
 	return func(urlTemplate string) MethodDefinition {
 		return NewMethodDefinition(
 			http.MethodDelete,
+			[]BeforeDoCallback{},
+			[]AfterDoCallback{IgnoreWhenDoesNotExistOrConflicts},
+			RequestCreator{
+				creator: func(urlCreator urlCreator, body []byte) (*http.Request, error) {
+					body = []byte(deleteOptions)
+					return newDefaultRequest(http.MethodDelete, urlCreator(urlTemplate), body)
+				}},
+			modifiers...)
+	}
+}
+
+func DELETEALL(modifiers ...MethodDefModifier) methodDefCreator {
+	return func(urlTemplate string) MethodDefinition {
+		return NewMethodDefinition(
+			MethodDeleteAll,
 			[]BeforeDoCallback{},
 			[]AfterDoCallback{IgnoreWhenDoesNotExistOrConflicts},
 			RequestCreator{

--- a/openshift/methods_whitebox_test.go
+++ b/openshift/methods_whitebox_test.go
@@ -55,6 +55,7 @@ func TestEachMethodSeparately(t *testing.T) {
 		request, err := methodDefinition.requestCreator.createRequestFor("http://starter", object[0], []byte(objectToBeParsed))
 		assert.NoError(t, err)
 		assert.Equal(t, "http://starter/targeting-object-name", request.URL.String())
+		assert.Equal(t, http.MethodPost, request.Method)
 	})
 
 	t.Run("PATCH method", func(t *testing.T) {
@@ -70,6 +71,7 @@ func TestEachMethodSeparately(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "http://starter/targeting-object-name", request.URL.String())
 		assert.Equal(t, "application/strategic-merge-patch+json", request.Header.Get("Content-Type"))
+		assert.Equal(t, http.MethodPatch, request.Method)
 	})
 
 	t.Run("DELETE method", func(t *testing.T) {
@@ -84,6 +86,22 @@ func TestEachMethodSeparately(t *testing.T) {
 		request, err := methodDefinition.requestCreator.createRequestFor("http://starter", object[0], []byte(objectToBeParsed))
 		assert.NoError(t, err)
 		assert.Equal(t, "http://starter/targeting-object-name", request.URL.String())
+		assert.Equal(t, http.MethodDelete, request.Method)
+	})
+
+	t.Run("DELETEALL method", func(t *testing.T) {
+		// when
+		methodDefinition := DELETEALL()(dummyEndpoint)
+
+		// then
+		assert.Empty(t, methodDefinition.beforeDoCallbacks)
+		assert.Len(t, methodDefinition.afterDoCallbacks, 1)
+		assert.Equal(t, methodDefinition.afterDoCallbacks[0].Name, IgnoreWhenDoesNotExistOrConflicts.Name)
+		assert.Equal(t, MethodDeleteAll, methodDefinition.action)
+		request, err := methodDefinition.requestCreator.createRequestFor("http://starter", object[0], []byte(objectToBeParsed))
+		assert.NoError(t, err)
+		assert.Equal(t, "http://starter/targeting-object-name", request.URL.String())
+		assert.Equal(t, http.MethodDelete, request.Method)
 	})
 
 	t.Run("GET method", func(t *testing.T) {
@@ -97,6 +115,7 @@ func TestEachMethodSeparately(t *testing.T) {
 		request, err := methodDefinition.requestCreator.createRequestFor("http://starter", object[0], []byte(objectToBeParsed))
 		assert.NoError(t, err)
 		assert.Equal(t, "http://starter/targeting-object-name", request.URL.String())
+		assert.Equal(t, http.MethodGet, request.Method)
 	})
 }
 

--- a/openshift/types_test.go
+++ b/openshift/types_test.go
@@ -124,7 +124,7 @@ func TestPresenceOfTemplateObjects(t *testing.T) {
 	t.Run("verify jenkins deployment config", func(t *testing.T) {
 		assert.NoError(t,
 			contain(templateObjects,
-				environment.ValKindPersistenceVolumeClaim,
+				environment.ValKindPersistentVolumeClaim,
 				withNamespace("developer-che")))
 	})
 

--- a/test/gock_matchers.go
+++ b/test/gock_matchers.go
@@ -8,7 +8,6 @@ import (
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"net/http"
-	"regexp"
 	"strings"
 )
 
@@ -91,12 +90,6 @@ func HasBodyContainingObject(object map[interface{}]interface{}) gock.MatchFunc 
 			return false, err
 		}
 		return string(body) == string(expBody), nil
-	}
-}
-
-func HasUrlMatching(regExp string) gock.MatchFunc {
-	return func(req *http.Request, gockReq *gock.Request) (bool, error) {
-		return regexp.MustCompile(regExp).MatchString(req.URL.String()), nil
 	}
 }
 


### PR DESCRIPTION
* clean should delete all resources (not only those that are in templates), otherwise, some objects created after the provisioning can also stay there
 * replaced printing on stdout by logrus warning
* increased waiting timeout for pvc being removed
* introduced `OperationSet` abstraction - it's a map of required action applied to set of objects - will be very useful for next features that are going to be implemented