### PR TITLE
chore: use callbacks as one nested function chain

### DIFF
--- a/openshift/action.go
+++ b/openshift/action.go
@@ -119,7 +119,7 @@ func (c *commonNamespaceAction) HealingStrategy() HealingFuncGenerator {
 }
 
 func (c *commonNamespaceAction) ManageAndUpdateResults(errorChan chan error, envTypes []environment.Type, healing Healing) error {
-	msg := utils.ListErrorsInMessage(errorChan)
+	msg := utils.ListErrorsInMessage(errorChan, 100)
 	if len(msg) > 0 {
 		err := fmt.Errorf("%s method applied to namespace types %s failed with one or more errors:%s", c.method, envTypes, msg)
 		if !c.actionOptions.allowSelfHealing {

--- a/openshift/callback.go
+++ b/openshift/callback.go
@@ -70,7 +70,7 @@ var GetObjectAndMerge = BeforeDoCallback{
 				return nil
 			})
 
-			msg := utils.ListErrorsInMessage(errorChan)
+			msg := utils.ListErrorsInMessage(errorChan, 100)
 			if len(msg) > 0 {
 				return nil, nil, fmt.Errorf("unable to finish the action %s on a object %s as there were %d of unsuccessful retries "+
 					"to get object and create a patch for the cluster %s. The retrieved errors:%s",
@@ -190,7 +190,7 @@ var GetObject = AfterDoCallback{
 				}
 				return nil
 			})
-			msg := utils.ListErrorsInMessage(errorChan)
+			msg := utils.ListErrorsInMessage(errorChan, 100)
 			if len(msg) > 0 {
 				return result, fmt.Errorf("unable to finish the action %s on a object %s as there were %d of unsuccessful retries "+
 					"to get the created objects from the cluster %s. The retrieved errors:%s",
@@ -254,16 +254,16 @@ var TryToWaitUntilIsGone = AfterDoCallback{
 				return fmt.Errorf("the object %s hasn't been removed nor set to terminating state "+
 					"- waiting till it is completely removed to finish the %s action", returnedObj, context.Method.action)
 			})
-			msg := utils.ListErrorsInMessage(errorChan)
+			msg := utils.ListErrorsInMessage(errorChan, 5)
 			if len(msg) > 0 {
 				// todo investigate why logging here ends with panic: runtime error: index out of range in common logic
 				logrus.WithFields(map[string]interface{}{
-					"action":        context.Method.action,
-					"object-kind":   environment.GetKind(context.Object),
-					"object-name":   environment.GetName(context.Object),
-					"namespace":     environment.GetNamespace(context.Object),
-					"cluster":       context.Client.MasterURL,
-					"error-message": msg,
+					"action":         context.Method.action,
+					"object-kind":    environment.GetKind(context.Object),
+					"object-name":    environment.GetName(context.Object),
+					"namespace":      environment.GetNamespace(context.Object),
+					"cluster":        context.Client.MasterURL,
+					"first-5-errors": msg,
 				}).Warnf("unable to finish the action %s for an object as there were %d of unsuccessful retries to completely remove the objects from the cluster",
 					context.Method.action, retries)
 			}

--- a/openshift/client.go
+++ b/openshift/client.go
@@ -70,14 +70,14 @@ func (c *Client) Do(requestCreator RequestCreator, object environment.Object, bo
 }
 
 type Result struct {
-	response *http.Response
+	Response *http.Response
 	Body     []byte
 	err      error
 }
 
 func NewResult(response *http.Response, body []byte, err error) *Result {
 	return &Result{
-		response: response,
+		Response: response,
 		Body:     body,
 		err:      err,
 	}

--- a/utils/error.go
+++ b/utils/error.go
@@ -2,10 +2,13 @@ package utils
 
 import "fmt"
 
-func ListErrorsInMessage(errorChan chan error) string {
+func ListErrorsInMessage(errorChan chan error, maxNumber int) string {
 	index := 1
 	msg := ""
 	for er := range errorChan {
+		if index > maxNumber {
+			break
+		}
 		if er != nil {
 			msg += fmt.Sprintf("\n#%d: %s", index, er.Error())
 			index++


### PR DESCRIPTION
* instead of calling callbacks in a loop nest all functions into one function and call it once - is better for handling the returned values and call results
* remove unused callback
* make warn log (that waits for complete deletion of pvc) shorter
