### PR TITLE
Add configmap in jenkins namespace for openshift-login plugin

### DIFF
--- a/environment/templates/fabric8-tenant-jenkins.yml
+++ b/environment/templates/fabric8-tenant-jenkins.yml
@@ -836,6 +836,41 @@ objects:
     to:
       kind: Service
       name: jenkins
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: jenkins
+      provider: fabric8
+      version: ${COMMIT}
+      version-quotas: ${COMMIT_QUOTAS}
+    name: openshift-jenkins-login-plugin-config
+    namespace: ${USER_NAME}-jenkins
+  data:
+    Overall-Read: admin,edit,view
+    Overall-RunScripts: admin,edit,view
+    Overall-Administer: admin
+    Job-Build: admin,edit,view
+    Job-Configure: admin,edit,view
+    Job-Create: admin,edit,view
+    Job-Delete: admin,edit,view
+    Job-Cancel: admin,edit,view
+    Job-Wokspace: admin,edit,view
+    Job-Read: admin,edit,view
+    Job-Discover: admin,edit,view
+    Run-Delete: admin
+    Run-Update: admin
+    View-Configure: admin
+    View-Create: admin
+    View-Delete: admin
+    Credentials-Create: admin
+    Credentials-Update: admin
+    Credentials-Delete: admin
+    Credentials-ManageDomains: admin
+    Credentials-View: admin,edit,view
+    SCM-Tag: admin,edit,view
+    Slave-Configure: admin
+    Slave-Delete: admin
 parameters:
 - name: USER_NAME
   value: developer


### PR DESCRIPTION
This will add a new configmap in jenkins namespace for
openshift login plugin.

Previously there were default roles in openshift-login plugin
and they can't be configured. Because of that we were using
a fork of upstream login plugin with roles configuration
according to our use case.

Now, a patch has been added in upstream login plugin through
which we can configure roles by providing a configmap

This patch will add the same configmap which will be used
by openshift-login plugin to configure roles.
We will deprecate our fork of login plugin and will move to
upstream version.

From image, we have removed our fork binary and used upstream
using this patch
fabric8io/openshift-jenkins-s2i-config#234

This will fix openshiftio/openshift.io#4608