### PR TITLE
 fix(#749): don't use "delete all" endpoints and clean all object one by one

### DIFF
--- a/controller/tenant_test.go
+++ b/controller/tenant_test.go
@@ -289,7 +289,7 @@ func (s *TenantControllerTestSuite) TestDeleteTenantOK() {
 			// when
 			apptest.CleanTenantNoContent(s.T(), createAndMockUserAndToken(s.T(), id.String(), false), svc, ctrl, false)
 			// then
-			assert.Equal(s.T(), testdoubles.ExpectedNumberOfCallsWhenClean(t, config, environment.DefaultEnvTypes...), calls)
+			assert.Equal(s.T(), testdoubles.ExpectedNumberOfCallsWhenClean(environment.DefaultEnvTypes...), calls)
 			assertion.AssertTenantFromService(t, repo, id).
 				Exists().
 				HasNumberOfNamespaces(5)

--- a/openshift/action_test.go
+++ b/openshift/action_test.go
@@ -323,7 +323,7 @@ func (s *ActionTestSuite) TestDeleteAction() {
 			Get("/.+/namespaces/johny-jenkins/[^/]+/$").
 			Times(len(openshift.AllToGetAndDelete)).
 			Reply(200).
-			BodyString(`{"items": []}`)
+			BodyString(`{"items": [{"metadata": {"name": "some-item"}}]}`)
 		toSort := getObjectsOfAllKinds()
 		// when
 		sets, err := delete.GetOperationSets(toSort, *client, "johny-jenkins")
@@ -333,9 +333,9 @@ func (s *ActionTestSuite) TestDeleteAction() {
 		length := len(toSort)
 		sorted, ok := sets["DELETE"]
 		require.True(t, ok)
-		assert.Equal(t, environment.ValKindProjectRequest, environment.GetKind(sorted[length-1]))
-		assert.Equal(t, environment.ValKindRole, environment.GetKind(sorted[length-2]))
-		assert.Equal(t, environment.ValKindRoleBindingRestriction, environment.GetKind(sorted[length-3]))
+		assert.Equal(t, environment.ValKindService, environment.GetKind(sorted[length-1]))
+		assert.Equal(t, environment.ValKindPersistentVolumeClaim, environment.GetKind(sorted[length-2]))
+		assert.Equal(t, environment.ValKindConfigMap, environment.GetKind(sorted[length-3]))
 	})
 
 	s.T().Run("GetOperationSets method should not fail when get returns 404 or 403", func(t *testing.T) {
@@ -538,7 +538,7 @@ func (s *ActionTestSuite) TestDeleteAction() {
 				HealingStrategy()(serviceBuilder)(fmt.Errorf("some error"))
 			// then
 			assert.NoError(t, err)
-			expectedNumberOfCalls := testdoubles.ExpectedNumberOfCallsWhenClean(t, config, environment.TypeJenkins, environment.TypeChe)
+			expectedNumberOfCalls := testdoubles.ExpectedNumberOfCallsWhenClean(environment.TypeJenkins, environment.TypeChe)
 			assert.EqualValues(t, expectedNumberOfCalls, calls)
 			assert.NoError(t, err)
 			assertion.AssertTenant(t, repo).

--- a/openshift/callback.go
+++ b/openshift/callback.go
@@ -215,7 +215,7 @@ var IgnoreWhenDoesNotExistOrConflicts = AfterDoCallback{
 					"object-kind": environment.GetKind(context.Object),
 					"object-name": environment.GetName(context.Object),
 					"namespace":   environment.GetNamespace(context.Object),
-					"message":     result.Body,
+					"message":     string(result.Body),
 				}).Warnf("failed to %s the object. Ignoring this error because it probably does not exist or is being removed",
 					context.Method.action)
 				return &Result{}, nil

--- a/openshift/endpoints.go
+++ b/openshift/endpoints.go
@@ -41,21 +41,21 @@ var (
 				PATCH(Require(MasterToken)), GET(Require(MasterToken)), DELETE(Require(MasterToken)))),
 
 		environment.ValKindRoute: endpoints(
-			endpoint(`/oapi/v1/namespaces/{{ index . "metadata" "namespace"}}/routes`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/oapi/v1/namespaces/{{ index . "metadata" "namespace"}}/routes`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
 			endpoint(`/oapi/v1/namespaces/{{ index . "metadata" "namespace"}}/routes/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 
 		environment.ValKindDeployment: endpoints(
-			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/deployments`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/deployments`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
 			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/deployments/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 
 		environment.ValKindDeploymentConfig: endpoints(
 			endpoint(`/apis/apps.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/deploymentconfigs`,
-				POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+				POST(AfterDo(WhenConflictThenDeleteAndRedo))),
 			endpoint(`/apis/apps.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/deploymentconfigs/{{ index . "metadata" "name"}}`,
 				PATCH(), GET(), DELETE())),
 
 		environment.ValKindPersistentVolumeClaim: endpoints(
-			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/persistentvolumeclaims`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/persistentvolumeclaims`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
 			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/persistentvolumeclaims/{{ index . "metadata" "name"}}`,
 				PATCH(), GET(), DELETE(AfterDo(TryToWaitUntilIsGone)))),
 
@@ -72,7 +72,7 @@ var (
 			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/serviceaccounts/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 
 		environment.ValKindConfigMap: endpoints(
-			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/configmaps`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/configmaps`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
 			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/configmaps/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 
 		environment.ValKindResourceQuota: endpoints(
@@ -84,47 +84,47 @@ var (
 			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/limitranges/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 
 		environment.ValKindJob: endpoints(
-			endpoint(`/apis/batch/v1/namespaces/{{ index . "metadata" "namespace"}}/jobs`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/apis/batch/v1/namespaces/{{ index . "metadata" "namespace"}}/jobs`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
 			endpoint(`/apis/batch/v1/namespaces/{{ index . "metadata" "namespace"}}/jobs/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 
 		environment.ValKindPod: endpoints(
-			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/pods`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/pods`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
 			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/pods/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 
 		environment.ValKindReplicationController: endpoints(
-			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/replicationcontrollers`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/replicationcontrollers`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
 			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/replicationcontrollers/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 
 		environment.ValKindDaemonSet: endpoints(
-			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/daemonsets`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/daemonsets`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
 			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/daemonsets/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 
 		environment.ValKindReplicaSet: endpoints(
-			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/replicasets`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/replicasets`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
 			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/replicasets/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 
 		environment.ValKindStatefulSet: endpoints(
-			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/statefulsets`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/statefulsets`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
 			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/statefulsets/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 
 		environment.ValKindHorizontalPodAutoScaler: endpoints(
-			endpoint(`/apis/autoscaling/v1/namespaces/{{ index . "metadata" "namespace"}}/horizontalpodautoscalers`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/apis/autoscaling/v1/namespaces/{{ index . "metadata" "namespace"}}/horizontalpodautoscalers`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
 			endpoint(`/apis/autoscaling/v1/namespaces/{{ index . "metadata" "namespace"}}/horizontalpodautoscalers/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 
 		environment.ValKindCronJob: endpoints(
-			endpoint(`/apis/batch/v1beta1/namespaces/{{ index . "metadata" "namespace"}}/cronjobs`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/apis/batch/v1beta1/namespaces/{{ index . "metadata" "namespace"}}/cronjobs`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
 			endpoint(`/apis/batch/v1beta1/namespaces/{{ index . "metadata" "namespace"}}/cronjobs/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 
 		environment.ValKindBuildConfig: endpoints(
-			endpoint(`/apis/build.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/buildconfigs`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/apis/build.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/buildconfigs`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
 			endpoint(`/apis/build.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/buildconfigs/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 
 		environment.ValKindBuild: endpoints(
-			endpoint(`/apis/build.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/builds`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/apis/build.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/builds`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
 			endpoint(`/apis/build.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/builds/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 
 		environment.ValKindImageStream: endpoints(
-			endpoint(`/apis/image.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/imagestreams`, POST(AfterDo(WhenConflictThenDeleteAndRedo)), DELETEALL()),
+			endpoint(`/apis/image.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/imagestreams`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
 			endpoint(`/apis/image.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/imagestreams/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
 	}
 	deleteOptions = `apiVersion: v1

--- a/openshift/methods.go
+++ b/openshift/methods.go
@@ -31,8 +31,6 @@ type methodDefCreator func(endpoint string) MethodDefinition
 type RequestCreatorModifier func(requestCreator RequestCreator) RequestCreator
 type MethodDefModifier func(*MethodDefinition) *MethodDefinition
 
-const MethodDeleteAll = "DELETEALL"
-
 type BeforeDoCallbackFuncCreator func(previousCallback BeforeDoCallbackFunc) BeforeDoCallbackFunc
 type BeforeDoCallbackFunc func(context CallbackContext) (*MethodDefinition, []byte, error)
 
@@ -156,21 +154,6 @@ func DELETE(modifiers ...MethodDefModifier) methodDefCreator {
 	return func(urlTemplate string) MethodDefinition {
 		return NewMethodDefinition(
 			http.MethodDelete,
-			[]BeforeDoCallback{},
-			[]AfterDoCallback{IgnoreWhenDoesNotExistOrConflicts},
-			RequestCreator{
-				creator: func(urlCreator urlCreator, body []byte) (*http.Request, error) {
-					body = []byte(deleteOptions)
-					return newDefaultRequest(http.MethodDelete, urlCreator(urlTemplate), body)
-				}},
-			modifiers...)
-	}
-}
-
-func DELETEALL(modifiers ...MethodDefModifier) methodDefCreator {
-	return func(urlTemplate string) MethodDefinition {
-		return NewMethodDefinition(
-			MethodDeleteAll,
 			[]BeforeDoCallback{},
 			[]AfterDoCallback{IgnoreWhenDoesNotExistOrConflicts},
 			RequestCreator{

--- a/openshift/methods_whitebox_test.go
+++ b/openshift/methods_whitebox_test.go
@@ -89,21 +89,6 @@ func TestEachMethodSeparately(t *testing.T) {
 		assert.Equal(t, http.MethodDelete, request.Method)
 	})
 
-	t.Run("DELETEALL method", func(t *testing.T) {
-		// when
-		methodDefinition := DELETEALL()(dummyEndpoint)
-
-		// then
-		assert.Empty(t, methodDefinition.beforeDoCallbacks)
-		assert.Len(t, methodDefinition.afterDoCallbacks, 1)
-		assert.Equal(t, methodDefinition.afterDoCallbacks[0].Name, IgnoreWhenDoesNotExistOrConflicts.Name)
-		assert.Equal(t, MethodDeleteAll, methodDefinition.action)
-		request, err := methodDefinition.requestCreator.createRequestFor("http://starter", object[0], []byte(objectToBeParsed))
-		assert.NoError(t, err)
-		assert.Equal(t, "http://starter/targeting-object-name", request.URL.String())
-		assert.Equal(t, http.MethodDelete, request.Method)
-	})
-
 	t.Run("GET method", func(t *testing.T) {
 		// when
 		methodDefinition := GET()(dummyEndpoint)

--- a/test/doubles/test_doubles.go
+++ b/test/doubles/test_doubles.go
@@ -248,7 +248,7 @@ func MockCleanRequestsToOS(calls *int, cluster string) {
 		SetMatcher(test.SpyOnCalls(calls)).
 		Persist().
 		Reply(200).
-		BodyString(`{"items": []}`)
+		BodyString(`{"items": [{"metadata": {"name": "first-item"}}, {"metadata": {"name": "second-item"}}]}`)
 	gock.New(cluster).
 		Get(`.*\/(persistentvolumeclaims)\/.*`).
 		SetMatcher(test.SpyOnCalls(calls)).
@@ -271,11 +271,9 @@ func ExpectedNumberOfCallsWhenPost(t *testing.T, config *configuration.Data) int
 	return len(objectsInTemplates) + NumberOfGetChecks(objectsInTemplates) + 1 + 5
 }
 
-func ExpectedNumberOfCallsWhenClean(t *testing.T, config *configuration.Data, envTypes ...environment.Type) int {
-	objectsInTemplates := RetrieveObjects(t, config, DefaultClusterMapping, DefaultUserInfo, envTypes...)
-	pvcNumber := CountObjectsThat(objectsInTemplates, isOfKind(environment.ValKindPersistentVolumeClaim))
-	cleanAllOps := (len(openshift.AllToGetAndDelete)) * len(envTypes)
-	return NumberOfObjectsToClean(objectsInTemplates) + pvcNumber + cleanAllOps
+func ExpectedNumberOfCallsWhenClean(envTypes ...environment.Type) int {
+	cleanAllOps := (len(openshift.AllToGetAndDelete)) * len(envTypes) * 3
+	return cleanAllOps + len(envTypes)*2
 }
 
 func ExpectedNumberOfCallsWhenPatch(t *testing.T, config *configuration.Data, envTypes ...environment.Type) int {


### PR DESCRIPTION
when doing clean action, instead of calling "delete all" endpoints (eg.  [delete all PVC](https://docs.openshift.com/container-platform/3.7/rest_api/api/v1.PersistentVolumeClaim.html#Delete-api-v1-namespaces-namespace-persistentvolumeclaims) ) for `all,pvc,cm` kinds retrieve all available objects of that kind for every namespace and delete the objects one by one. 

Fixes: #749