### PR TITLE
fix(#751): when doing clean wait until objects are removed

### DIFF
--- a/openshift/action.go
+++ b/openshift/action.go
@@ -297,9 +297,13 @@ func (d *DeleteAction) GetOperationSets(envService EnvironmentTypeService, clien
 		if err != nil {
 			return env, nil, err
 		}
+		operationSets = append(operationSets, NewOperationSet(http.MethodDelete, toDelete))
+		operationSets = append(operationSets, NewOperationSet(EnsureDeletion, toDelete))
+	} else {
+		operationSets = append(operationSets, NewOperationSet(http.MethodDelete, toDelete))
 	}
+
 	sort.Sort(sort.Reverse(environment.ByKind(toDelete)))
-	operationSets = append(operationSets, NewOperationSet(http.MethodDelete, toDelete))
 	return env, operationSets, nil
 }
 

--- a/openshift/action_test.go
+++ b/openshift/action_test.go
@@ -363,13 +363,16 @@ func (s *ActionTestSuite) TestDeleteAction() {
 		_, sets, err := delete.GetOperationSets(NewAllTypesService(nil, false), *client)
 		// then
 		assert.NoError(t, err)
-		assert.Len(t, sets, 1)
+		assert.Len(t, sets, 2)
 		length := len(toSort)
 		deleteSet := sets[0]
 		assert.Equal(t, "DELETE", deleteSet.Method)
 		assert.Equal(t, environment.ValKindService, environment.GetKind(deleteSet.Objects[length-1]))
 		assert.Equal(t, environment.ValKindPersistentVolumeClaim, environment.GetKind(deleteSet.Objects[length-2]))
 		assert.Equal(t, environment.ValKindConfigMap, environment.GetKind(deleteSet.Objects[length-3]))
+
+		assert.Equal(t, openshift.EnsureDeletion, sets[1].Method)
+		assert.Equal(t, deleteSet.Objects, sets[1].Objects)
 	})
 
 	s.T().Run("GetOperationSets method should not fail when get returns 404 or 403", func(t *testing.T) {
@@ -387,7 +390,7 @@ func (s *ActionTestSuite) TestDeleteAction() {
 		_, sets, err := delete.GetOperationSets(NewAllTypesService(nil, false), *client)
 		// then
 		assert.NoError(t, err)
-		assert.Len(t, sets, 1)
+		assert.Len(t, sets, 2)
 	})
 
 	s.T().Run("GetOperationSets method should fail when get returns 505", func(t *testing.T) {
@@ -425,7 +428,7 @@ func (s *ActionTestSuite) TestDeleteAction() {
 		_, sets, err := delete.GetOperationSets(allTypesService, *client)
 		// then
 		assert.NoError(t, err)
-		assert.Len(t, sets, 1)
+		assert.Len(t, sets, 2)
 		deleteSet := sets[0]
 		assert.Equal(t, "DELETE", deleteSet.Method)
 		require.Len(t, deleteSet.Objects, 3)
@@ -435,6 +438,9 @@ func (s *ActionTestSuite) TestDeleteAction() {
 		assert.Equal(t, "jenkins", environment.GetName(deleteSet.Objects[1]))
 		assert.Equal(t, environment.ValKindService, environment.GetKind(deleteSet.Objects[2]))
 		assert.Equal(t, "jenkins-jnlp", environment.GetName(deleteSet.Objects[2]))
+
+		assert.Equal(t, openshift.EnsureDeletion, sets[1].Method)
+		assert.Equal(t, deleteSet.Objects, sets[1].Objects)
 	})
 
 	s.T().Run("GetOperationSets method should do reverse sorted and and not delete all objects for remove", func(t *testing.T) {

--- a/openshift/callback.go
+++ b/openshift/callback.go
@@ -31,6 +31,7 @@ const (
 	GetObjectName                     = "GetObject"
 	IgnoreWhenDoesNotExistName        = "IgnoreWhenDoesNotExistOrConflicts"
 	TryToWaitUntilIsGoneName          = "TryToWaitUntilIsGone"
+	WaitUntilIsRemovedName            = "WaitUntilIsRemoved"
 )
 
 // Before callbacks
@@ -120,6 +121,47 @@ var FailIfAlreadyExists = BeforeDoCallback{
 		}
 	},
 	Name: FailIfExistsName,
+}
+
+func WaitUntilIsRemoved(doCheckAndContinue bool) BeforeDoCallback {
+	return BeforeDoCallback{
+		Create: func(previousCallback BeforeDoCallbackFunc) BeforeDoCallbackFunc {
+			return func(context CallbackContext) (*MethodDefinition, []byte, error) {
+				method, body, err := previousCallback(context)
+				if err != nil {
+					return method, body, err
+				}
+				if !doCheckAndContinue {
+					return nil, nil, nil
+				}
+				retries := 30
+				msg := waitUntilIsGone(context, retries, false)
+				if len(msg) > 0 {
+					logrus.WithFields(map[string]interface{}{
+						"action":         context.Method.action,
+						"object-kind":    environment.GetKind(context.Object),
+						"object-name":    environment.GetName(context.Object),
+						"namespace":      environment.GetNamespace(context.Object),
+						"cluster":        context.Client.MasterURL,
+						"first-5-errors": msg,
+					}).Warnf("The object wasn't removed - checked in %d of unsuccessful retries", retries)
+					return addAfterDoCallbackIfNotExist(*method, TryToWaitUntilIsGone), body, err
+				}
+				return nil, nil, nil
+			}
+		},
+		Name: WaitUntilIsRemovedName,
+	}
+}
+
+func addAfterDoCallbackIfNotExist(method MethodDefinition, callbackToAdd AfterDoCallback) *MethodDefinition {
+	for _, callback := range method.afterDoCallbacks {
+		if callback.Name == callbackToAdd.Name {
+			return &method
+		}
+	}
+	method.afterDoCallbacks = append(method.afterDoCallbacks, callbackToAdd)
+	return &method
 }
 
 // After callbacks
@@ -235,26 +277,7 @@ var TryToWaitUntilIsGone = AfterDoCallback{
 				return result, err
 			}
 			retries := 60
-			errorChan := retry.Do(retries, time.Millisecond*500, func() error {
-				result, err := context.ObjEndpoints.Apply(context.Client, context.Object, http.MethodGet)
-				if result != nil && isNotPresent(result.Response.StatusCode) {
-					return nil
-				}
-				if err != nil {
-					return err
-				}
-				var returnedObj environment.Object
-				err = yaml.Unmarshal(result.Body, &returnedObj)
-				if err != nil {
-					return errors.Wrapf(err, "unable unmarshal object responded from OS while doing GET method")
-				}
-				if isInTerminatingState(returnedObj) {
-					return nil
-				}
-				return fmt.Errorf("the object %s hasn't been removed nor set to terminating state "+
-					"- waiting till it is completely removed to finish the %s action", returnedObj, context.Method.action)
-			})
-			msg := utils.ListErrorsInMessage(errorChan, 5)
+			msg := waitUntilIsGone(context, retries, true)
 			if len(msg) > 0 {
 				// todo investigate why logging here ends with panic: runtime error: index out of range in common logic
 				logrus.WithFields(map[string]interface{}{
@@ -271,6 +294,32 @@ var TryToWaitUntilIsGone = AfterDoCallback{
 		}
 	},
 	Name: TryToWaitUntilIsGoneName,
+}
+
+func waitUntilIsGone(context CallbackContext, retries int, checkTerminating bool) string {
+	errorChan := retry.Do(retries, time.Millisecond*500, func() error {
+		result, err := context.ObjEndpoints.Apply(context.Client, context.Object, http.MethodGet)
+		if result != nil && isNotPresent(result.Response.StatusCode) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		var returnedObj environment.Object
+		err = yaml.Unmarshal(result.Body, &returnedObj)
+		if err != nil {
+			return errors.Wrapf(err, "unable unmarshal object responded from OS while doing GET method")
+		}
+		errMsgPrefix := fmt.Sprintf("the object %s hasn't been removed ", returnedObj)
+		if checkTerminating {
+			if isInTerminatingState(returnedObj) {
+				return nil
+			}
+			errMsgPrefix += "nor set to terminating state "
+		}
+		return fmt.Errorf("%s - waiting till it is completely removed to finish the %s action", errMsgPrefix, context.Method.action)
+	})
+	return utils.ListErrorsInMessage(errorChan, 5)
 }
 
 func isNotPresent(statusCode int) bool {

--- a/openshift/endpoints.go
+++ b/openshift/endpoints.go
@@ -17,115 +17,136 @@ var (
 	AllObjectEndpoints = map[string]*ObjectEndpoints{
 		environment.ValKindNamespace: endpoints(
 			endpoint(`/api/v1/namespaces`, POST(BeforeDo(FailIfAlreadyExists), AfterDo(GetObject))),
-			endpoint(`/api/v1/namespaces/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+			endpoint(`/api/v1/namespaces/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE(), ENSURE_DELETION(false))),
 
 		environment.ValKindProject: endpoints(
 			endpoint(`/oapi/v1/projects`, POST(BeforeDo(FailIfAlreadyExists), AfterDo(GetObject))),
-			endpoint(`/oapi/v1/projects/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+			endpoint(`/oapi/v1/projects/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE(), ENSURE_DELETION(false))),
 
 		environment.ValKindProjectRequest: endpoints(
 			endpoint(`/oapi/v1/projectrequests`, POST(BeforeDo(FailIfAlreadyExists), AfterDo(GetObject))),
-			endpoint(`/oapi/v1/projects/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+			endpoint(`/oapi/v1/projects/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE(), ENSURE_DELETION(false))),
 
 		environment.ValKindRole: endpoints(
 			endpoint(`/oapi/v1/namespaces/{{ index . "metadata" "namespace"}}/roles`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
-			endpoint(`/oapi/v1/namespaces/{{ index . "metadata" "namespace"}}/roles/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+			endpoint(`/oapi/v1/namespaces/{{ index . "metadata" "namespace"}}/roles/{{ index . "metadata" "name"}}`,
+				PATCH(), GET(), DELETE(), ENSURE_DELETION(true))),
 
 		environment.ValKindRoleBinding: endpoints(
 			endpoint(`/oapi/v1/namespaces/{{ index . "metadata" "namespace"}}/rolebindings`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
-			endpoint(`/oapi/v1/namespaces/{{ index . "metadata" "namespace"}}/rolebindings/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE(Require(MasterToken)))),
+			endpoint(`/oapi/v1/namespaces/{{ index . "metadata" "namespace"}}/rolebindings/{{ index . "metadata" "name"}}`,
+				PATCH(), GET(), DELETE(Require(MasterToken)), ENSURE_DELETION(true))),
 
 		environment.ValKindRoleBindingRestriction: endpoints(
 			endpoint(`/oapi/v1/namespaces/{{ index . "metadata" "namespace"}}/rolebindingrestrictions`, POST(Require(MasterToken), AfterDo(WhenConflictThenDeleteAndRedo))),
 			endpoint(`/oapi/v1/namespaces/{{ index . "metadata" "namespace"}}/rolebindingrestrictions/{{ index . "metadata" "name"}}`,
-				PATCH(Require(MasterToken)), GET(Require(MasterToken)), DELETE(Require(MasterToken)))),
+				PATCH(Require(MasterToken)), GET(Require(MasterToken)), DELETE(Require(MasterToken)), ENSURE_DELETION(true))),
 
 		environment.ValKindRoute: endpoints(
 			endpoint(`/oapi/v1/namespaces/{{ index . "metadata" "namespace"}}/routes`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
-			endpoint(`/oapi/v1/namespaces/{{ index . "metadata" "namespace"}}/routes/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+			endpoint(`/oapi/v1/namespaces/{{ index . "metadata" "namespace"}}/routes/{{ index . "metadata" "name"}}`,
+				PATCH(), GET(), DELETE(), ENSURE_DELETION(true))),
 
 		environment.ValKindDeployment: endpoints(
 			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/deployments`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
-			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/deployments/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/deployments/{{ index . "metadata" "name"}}`,
+				PATCH(), GET(), DELETE(), ENSURE_DELETION(true))),
 
 		environment.ValKindDeploymentConfig: endpoints(
 			endpoint(`/apis/apps.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/deploymentconfigs`,
 				POST(AfterDo(WhenConflictThenDeleteAndRedo))),
 			endpoint(`/apis/apps.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/deploymentconfigs/{{ index . "metadata" "name"}}`,
-				PATCH(), GET(), DELETE())),
+				PATCH(), GET(), DELETE(), ENSURE_DELETION(true))),
 
 		environment.ValKindPersistentVolumeClaim: endpoints(
 			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/persistentvolumeclaims`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
 			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/persistentvolumeclaims/{{ index . "metadata" "name"}}`,
-				PATCH(), GET(), DELETE(AfterDo(TryToWaitUntilIsGone)))),
+				PATCH(), GET(), DELETE(AfterDo(TryToWaitUntilIsGone)), ENSURE_DELETION(false))),
 
 		environment.ValKindService: endpoints(
 			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/services`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
-			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/services/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/services/{{ index . "metadata" "name"}}`,
+				PATCH(), GET(), DELETE(), ENSURE_DELETION(true))),
 
 		environment.ValKindSecret: endpoints(
 			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/secrets`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
-			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/secrets/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/secrets/{{ index . "metadata" "name"}}`,
+				PATCH(), GET(), DELETE(), ENSURE_DELETION(true))),
 
 		environment.ValKindServiceAccount: endpoints(
 			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/serviceaccounts`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
-			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/serviceaccounts/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/serviceaccounts/{{ index . "metadata" "name"}}`,
+				PATCH(), GET(), DELETE(), ENSURE_DELETION(true))),
 
 		environment.ValKindConfigMap: endpoints(
 			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/configmaps`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
-			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/configmaps/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/configmaps/{{ index . "metadata" "name"}}`,
+				PATCH(), GET(), DELETE(), ENSURE_DELETION(true))),
 
 		environment.ValKindResourceQuota: endpoints(
 			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/resourcequotas`, POST(AfterDo(WhenConflictThenDeleteAndRedo, GetObject))),
-			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/resourcequotas/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/resourcequotas/{{ index . "metadata" "name"}}`,
+				PATCH(), GET(), DELETE(), ENSURE_DELETION(true))),
 
 		environment.ValKindLimitRange: endpoints(
 			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/limitranges`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
-			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/limitranges/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/limitranges/{{ index . "metadata" "name"}}`,
+				PATCH(), GET(), DELETE(), ENSURE_DELETION(true))),
 
 		environment.ValKindJob: endpoints(
 			endpoint(`/apis/batch/v1/namespaces/{{ index . "metadata" "namespace"}}/jobs`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
-			endpoint(`/apis/batch/v1/namespaces/{{ index . "metadata" "namespace"}}/jobs/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+			endpoint(`/apis/batch/v1/namespaces/{{ index . "metadata" "namespace"}}/jobs/{{ index . "metadata" "name"}}`,
+				PATCH(), GET(), DELETE(), ENSURE_DELETION(true))),
 
 		environment.ValKindPod: endpoints(
 			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/pods`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
-			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/pods/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/pods/{{ index . "metadata" "name"}}`,
+				PATCH(), GET(), DELETE(), ENSURE_DELETION(true))),
 
 		environment.ValKindReplicationController: endpoints(
 			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/replicationcontrollers`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
-			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/replicationcontrollers/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+			endpoint(`/api/v1/namespaces/{{ index . "metadata" "namespace"}}/replicationcontrollers/{{ index . "metadata" "name"}}`,
+				PATCH(), GET(), DELETE(), ENSURE_DELETION(true))),
 
 		environment.ValKindDaemonSet: endpoints(
 			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/daemonsets`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
-			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/daemonsets/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/daemonsets/{{ index . "metadata" "name"}}`,
+				PATCH(), GET(), DELETE(), ENSURE_DELETION(true))),
 
 		environment.ValKindReplicaSet: endpoints(
 			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/replicasets`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
-			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/replicasets/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/replicasets/{{ index . "metadata" "name"}}`,
+				PATCH(), GET(), DELETE(), ENSURE_DELETION(true))),
 
 		environment.ValKindStatefulSet: endpoints(
 			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/statefulsets`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
-			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/statefulsets/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+			endpoint(`/apis/apps/v1/namespaces/{{ index . "metadata" "namespace"}}/statefulsets/{{ index . "metadata" "name"}}`,
+				PATCH(), GET(), DELETE(), ENSURE_DELETION(true))),
 
 		environment.ValKindHorizontalPodAutoScaler: endpoints(
 			endpoint(`/apis/autoscaling/v1/namespaces/{{ index . "metadata" "namespace"}}/horizontalpodautoscalers`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
-			endpoint(`/apis/autoscaling/v1/namespaces/{{ index . "metadata" "namespace"}}/horizontalpodautoscalers/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+			endpoint(`/apis/autoscaling/v1/namespaces/{{ index . "metadata" "namespace"}}/horizontalpodautoscalers/{{ index . "metadata" "name"}}`,
+				PATCH(), GET(), DELETE(), ENSURE_DELETION(true))),
 
 		environment.ValKindCronJob: endpoints(
 			endpoint(`/apis/batch/v1beta1/namespaces/{{ index . "metadata" "namespace"}}/cronjobs`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
-			endpoint(`/apis/batch/v1beta1/namespaces/{{ index . "metadata" "namespace"}}/cronjobs/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+			endpoint(`/apis/batch/v1beta1/namespaces/{{ index . "metadata" "namespace"}}/cronjobs/{{ index . "metadata" "name"}}`,
+				PATCH(), GET(), DELETE(), ENSURE_DELETION(true))),
 
 		environment.ValKindBuildConfig: endpoints(
 			endpoint(`/apis/build.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/buildconfigs`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
-			endpoint(`/apis/build.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/buildconfigs/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+			endpoint(`/apis/build.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/buildconfigs/{{ index . "metadata" "name"}}`,
+				PATCH(), GET(), DELETE(), ENSURE_DELETION(true))),
 
 		environment.ValKindBuild: endpoints(
 			endpoint(`/apis/build.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/builds`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
-			endpoint(`/apis/build.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/builds/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+			endpoint(`/apis/build.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/builds/{{ index . "metadata" "name"}}`,
+				PATCH(), GET(), DELETE(), ENSURE_DELETION(true))),
 
 		environment.ValKindImageStream: endpoints(
 			endpoint(`/apis/image.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/imagestreams`, POST(AfterDo(WhenConflictThenDeleteAndRedo))),
-			endpoint(`/apis/image.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/imagestreams/{{ index . "metadata" "name"}}`, PATCH(), GET(), DELETE())),
+			endpoint(`/apis/image.openshift.io/v1/namespaces/{{ index . "metadata" "namespace"}}/imagestreams/{{ index . "metadata" "name"}}`,
+				PATCH(), GET(), DELETE(), ENSURE_DELETION(true))),
 	}
 	deleteOptions = `apiVersion: v1
 kind: DeleteOptions
@@ -181,6 +202,9 @@ func (e *ObjectEndpoints) apply(client *Client, object environment.Object, metho
 	method, reqBody, err = method.beforeDoCallbacks.call(NewCallbackContext(client, object, e, method))
 	if err != nil {
 		return nil, err
+	}
+	if method == nil && reqBody == nil {
+		return &Result{}, nil
 	}
 
 	// do the request

--- a/openshift/methods_whitebox_test.go
+++ b/openshift/methods_whitebox_test.go
@@ -89,6 +89,22 @@ func TestEachMethodSeparately(t *testing.T) {
 		assert.Equal(t, http.MethodDelete, request.Method)
 	})
 
+	t.Run("ENSURE_DELETION method", func(t *testing.T) {
+		// when
+		methodDefinition := ENSURE_DELETION(true)(dummyEndpoint)
+
+		// then
+		assert.Len(t, methodDefinition.beforeDoCallbacks, 1)
+		assert.Equal(t, methodDefinition.beforeDoCallbacks[0].Name, WaitUntilIsRemoved(true).Name)
+		assert.Len(t, methodDefinition.afterDoCallbacks, 1)
+		assert.Equal(t, methodDefinition.afterDoCallbacks[0].Name, IgnoreWhenDoesNotExistOrConflicts.Name)
+		assert.Equal(t, EnsureDeletion, methodDefinition.action)
+		request, err := methodDefinition.requestCreator.createRequestFor("http://starter", object[0], []byte(objectToBeParsed))
+		assert.NoError(t, err)
+		assert.Equal(t, "http://starter/targeting-object-name", request.URL.String())
+		assert.Equal(t, http.MethodDelete, request.Method)
+	})
+
 	t.Run("GET method", func(t *testing.T) {
 		// when
 		methodDefinition := GET()(dummyEndpoint)


### PR DESCRIPTION
adds a new method `EnsureDeletion` (used only for deletion) that gets the objects and waits for 15s for their removal (response code is 404 or 403). This is added mainly to wait for pods/replicacontroller removal to avoid race conditions in OS

Fixes: #751,  #749
