### PR TITLE
fix: returns conflict on duplicate key errors&set params in updater

### DIFF
--- a/controller/tenant.go
+++ b/controller/tenant.go
@@ -16,6 +16,7 @@ import (
 	"github.com/goadesign/goa"
 	errs "github.com/pkg/errors"
 	"github.com/satori/go.uuid"
+	"strings"
 )
 
 // TenantController implements the tenant resource.
@@ -175,6 +176,9 @@ func (c *TenantController) Setup(ctx *app.SetupTenantContext) error {
 		}
 		err = tenantRepository.CreateTenant(dbTenant)
 		if err != nil {
+			if strings.Contains(err.Error(), "pq: duplicate key value violates unique constraint") {
+				return ctx.Conflict()
+			}
 			log.Error(ctx, map[string]interface{}{
 				"err": err,
 			}, "unable to store tenant configuration")

--- a/controller/tenant_test.go
+++ b/controller/tenant_test.go
@@ -105,8 +105,7 @@ func (s *TenantControllerTestSuite) TestSetupTenantOKWhenNoTenantExistsInParalle
 	var run sync.WaitGroup
 	run.Add(1)
 
-	fxt := tf.FillDB(s.T(), s.DB, tf.AddSpecificTenants(tf.SingleWithName("johny")), tf.AddNamespaces())
-	id := fxt.Tenants[0].ID
+	id := uuid.NewV4()
 
 	deleteCalls := 0
 	gock.New("http://api.cluster1").
@@ -131,7 +130,12 @@ func (s *TenantControllerTestSuite) TestSetupTenantOKWhenNoTenantExistsInParalle
 			run.Wait()
 
 			// when
-			ctrl.Setup(setupCtx)
+			err = ctrl.Setup(setupCtx)
+
+			// then
+			if err != nil {
+				assert.Equal(s.T(), err, test.IsOfType(setupCtx.Conflict()))
+			}
 		}()
 	}
 	run.Done()
@@ -188,7 +192,12 @@ func (s *TenantControllerTestSuite) TestSetupTenantOKWhenNoTenantExistsInParalle
 				run.Wait()
 
 				// when
-				ctrl.Setup(setupCtx)
+				err = ctrl.Setup(setupCtx)
+
+				// then
+				if err != nil {
+					assert.Equal(s.T(), err, test.IsOfType(setupCtx.Conflict()))
+				}
 			}()
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -113,10 +113,15 @@ func main() {
 
 	tenantService := tenant.NewDBService(db)
 
+	tenantUpdater := controller.TenantUpdater{
+		Config:         config,
+		TenantService:  tenantService,
+		ClusterService: clusterService,
+	}
 	// Check & do all tenants update
 	if config.IsAutomatedUpdateEnabled() {
 		log.Info(nil, map[string]interface{}{}, "automated update is enabled")
-		go update.NewTenantsUpdater(db, config, clusterService, controller.TenantUpdater{}, update.AllTypes, "").UpdateAllTenants()
+		go update.NewTenantsUpdater(db, config, clusterService, tenantUpdater, update.AllTypes, "").UpdateAllTenants()
 	} else {
 		log.Info(nil, map[string]interface{}{}, "automated update is disabled")
 	}
@@ -133,7 +138,7 @@ func main() {
 	app.MountTenantsController(service, tenantsCtrl)
 
 	// Mount "update" controller
-	updateCtrl := controller.NewUpdateController(service, db, config, clusterService, controller.TenantUpdater{})
+	updateCtrl := controller.NewUpdateController(service, db, config, clusterService, tenantUpdater)
 	app.MountUpdateController(service, updateCtrl)
 
 	log.Logger().Infoln("Git Commit SHA: ", configuration.Commit)


### PR DESCRIPTION
* When there is an error containing `pq: duplicate key value violates unique constraint` returned on the creation of tenant entity in DB, then it means that there is already one created so it should return a conflict (this happens when there are two POST call at the same time)
* construct TenantUpdater in main.go correctly to not panic