### PR TITLE
fix: don't modify che edit rights when context is nil

### DIFF
--- a/openshift/types.go
+++ b/openshift/types.go
@@ -111,6 +111,9 @@ type CheNamespaceTypeService struct {
 }
 
 func (t *CheNamespaceTypeService) AdditionalObject() (environment.Object, bool) {
+	if t.context.requestCtx == nil {
+		return environment.Object{}, true
+	}
 	return t.newEditRightsObject(), t.isToggleEnabled(t.context.requestCtx, "che.edit.rights", false)
 }
 


### PR DESCRIPTION
don't modify che edit rights (add/remove) when request context is nil - in case of cluster update