### PR TITLE
feat(ODC-238): add tenant related monitoring metrics 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -366,11 +366,12 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:735956b5e94182229dfbdc5b401d7a71f20f54f1259dbc2969ec2b56bfbb34f2"
+  digest = "1:26663fafdea73a38075b07e8e9d82fc0056379d2be8bb4e13899e8fda7c7dd23"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
     "prometheus/internal",
+    "prometheus/promhttp",
   ]
   pruneopts = "UT"
   revision = "abad2d1bd44235a26707c172eab6bca5bf2dbad3"
@@ -645,6 +646,8 @@
     "github.com/lib/pq",
     "github.com/pkg/errors",
     "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
+    "github.com/prometheus/client_model/go",
     "github.com/satori/go.uuid",
     "github.com/sirupsen/logrus",
     "github.com/spf13/cobra",

--- a/metric/metric.go
+++ b/metric/metric.go
@@ -1,0 +1,84 @@
+package metric
+
+import (
+	"github.com/fabric8-services/fabric8-common/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"strconv"
+)
+
+var (
+	ProvisionedTenantsCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "provisioned_tenants",
+		Help: "Total number of the provisioned tenants",
+	}, []string{"successful"})
+	CleanedTenantsCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "cleaned_tenants",
+		Help: "Total number of cleaned tenants",
+	}, []string{"successful", "nsBaseName"})
+	UpdatedTenantsCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "updated_tenants",
+		Help: "Total number of updated tenants",
+	}, []string{"successful", "nsBaseName"})
+)
+
+func RegisterMetrics() {
+	ProvisionedTenantsCounter = register(ProvisionedTenantsCounter, "provisioned_tenants").(*prometheus.CounterVec)
+	CleanedTenantsCounter = register(CleanedTenantsCounter, "cleaned_tenants").(*prometheus.CounterVec)
+	UpdatedTenantsCounter = register(UpdatedTenantsCounter, "updated_tenants").(*prometheus.CounterVec)
+	log.Info(nil, nil, "metrics registered successfully")
+}
+
+func register(collector prometheus.Collector, name string) prometheus.Collector {
+	err := prometheus.Register(collector)
+	if err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			return are.ExistingCollector
+		}
+		log.Panic(nil, map[string]interface{}{
+			"metric_name": name,
+			"err":         err,
+		}, "failed to register the prometheus metric")
+	}
+	log.Info(nil, map[string]interface{}{
+		"metric_name": name,
+	}, "metric registered successfully")
+	return collector
+}
+
+func RecordProvisionedTenant(successful bool) {
+	if counter, err := ProvisionedTenantsCounter.GetMetricWithLabelValues(strconv.FormatBool(successful)); err != nil {
+		log.Error(nil, map[string]interface{}{
+			"metric_name": "provisioned_tenants",
+			"successful":  successful,
+			"err":         err,
+		}, "Failed to get metric")
+	} else {
+		counter.Inc()
+	}
+}
+
+func RecordCleanedTenant(successful bool, nsBaseName string) {
+	if counter, err := CleanedTenantsCounter.GetMetricWithLabelValues(strconv.FormatBool(successful), nsBaseName); err != nil {
+		log.Error(nil, map[string]interface{}{
+			"metric_name": "cleaned_tenants",
+			"successful":  successful,
+			"nsBaseName":  nsBaseName,
+			"err":         err,
+		}, "Failed to get metric")
+	} else {
+		counter.Inc()
+	}
+}
+
+func RecordUpdatedTenant(successful bool, nsBaseName string) {
+	if counter, err := UpdatedTenantsCounter.GetMetricWithLabelValues(strconv.FormatBool(successful), nsBaseName); err != nil {
+		log.Error(nil, map[string]interface{}{
+			"metric_name": "updated_tenants",
+			"successful":  successful,
+			"nsBaseName":  nsBaseName,
+			"err":         err,
+		}, "Failed to get metric")
+	} else {
+		counter.Inc()
+	}
+}

--- a/metric/metric.go
+++ b/metric/metric.go
@@ -8,23 +8,23 @@ import (
 
 var (
 	ProvisionedTenantsCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "provisioned_tenants",
+		Name: "provisioned_tenants_total",
 		Help: "Total number of the provisioned tenants",
 	}, []string{"successful"})
 	CleanedTenantsCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "cleaned_tenants",
+		Name: "cleaned_tenants_total",
 		Help: "Total number of cleaned tenants",
 	}, []string{"successful", "nsBaseName"})
 	UpdatedTenantsCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "updated_tenants",
+		Name: "updated_tenants_total",
 		Help: "Total number of updated tenants",
 	}, []string{"successful", "nsBaseName"})
 )
 
 func RegisterMetrics() {
-	ProvisionedTenantsCounter = register(ProvisionedTenantsCounter, "provisioned_tenants").(*prometheus.CounterVec)
-	CleanedTenantsCounter = register(CleanedTenantsCounter, "cleaned_tenants").(*prometheus.CounterVec)
-	UpdatedTenantsCounter = register(UpdatedTenantsCounter, "updated_tenants").(*prometheus.CounterVec)
+	ProvisionedTenantsCounter = register(ProvisionedTenantsCounter, "provisioned_tenants_total").(*prometheus.CounterVec)
+	CleanedTenantsCounter = register(CleanedTenantsCounter, "cleaned_tenants_total").(*prometheus.CounterVec)
+	UpdatedTenantsCounter = register(UpdatedTenantsCounter, "updated_tenants_total").(*prometheus.CounterVec)
 	log.Info(nil, nil, "metrics registered successfully")
 }
 
@@ -48,7 +48,7 @@ func register(collector prometheus.Collector, name string) prometheus.Collector 
 func RecordProvisionedTenant(successful bool) {
 	if counter, err := ProvisionedTenantsCounter.GetMetricWithLabelValues(strconv.FormatBool(successful)); err != nil {
 		log.Error(nil, map[string]interface{}{
-			"metric_name": "provisioned_tenants",
+			"metric_name": "provisioned_tenants_total",
 			"successful":  successful,
 			"err":         err,
 		}, "Failed to get metric")
@@ -60,7 +60,7 @@ func RecordProvisionedTenant(successful bool) {
 func RecordCleanedTenant(successful bool, nsBaseName string) {
 	if counter, err := CleanedTenantsCounter.GetMetricWithLabelValues(strconv.FormatBool(successful), nsBaseName); err != nil {
 		log.Error(nil, map[string]interface{}{
-			"metric_name": "cleaned_tenants",
+			"metric_name": "cleaned_tenants_total",
 			"successful":  successful,
 			"nsBaseName":  nsBaseName,
 			"err":         err,
@@ -73,7 +73,7 @@ func RecordCleanedTenant(successful bool, nsBaseName string) {
 func RecordUpdatedTenant(successful bool, nsBaseName string) {
 	if counter, err := UpdatedTenantsCounter.GetMetricWithLabelValues(strconv.FormatBool(successful), nsBaseName); err != nil {
 		log.Error(nil, map[string]interface{}{
-			"metric_name": "updated_tenants",
+			"metric_name": "updated_tenants_total",
 			"successful":  successful,
 			"nsBaseName":  nsBaseName,
 			"err":         err,

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -1,0 +1,190 @@
+package metric_test
+
+import (
+	"github.com/fabric8-services/fabric8-common/convert/ptr"
+	"github.com/fabric8-services/fabric8-tenant/configuration"
+	"github.com/fabric8-services/fabric8-tenant/controller"
+	"github.com/fabric8-services/fabric8-tenant/environment"
+	"github.com/fabric8-services/fabric8-tenant/metric"
+	"github.com/fabric8-services/fabric8-tenant/tenant"
+	"github.com/fabric8-services/fabric8-tenant/test"
+	"github.com/fabric8-services/fabric8-tenant/test/doubles"
+	"github.com/fabric8-services/fabric8-tenant/test/gormsupport"
+	tf "github.com/fabric8-services/fabric8-tenant/test/testfixture"
+	"github.com/goadesign/goa"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/h2non/gock.v1"
+	"testing"
+
+	apptest "github.com/fabric8-services/fabric8-tenant/app/test"
+	dto "github.com/prometheus/client_model/go"
+)
+
+type MetricTestSuite struct {
+	gormsupport.DBTestSuite
+}
+
+func TestMetric(t *testing.T) {
+	suite.Run(t, &MetricTestSuite{DBTestSuite: gormsupport.NewDBTestSuite("../config.yaml")})
+}
+
+func (s *MetricTestSuite) TestFailedProvisionedTenantMetric() {
+	// given
+	defer unRegisterAndResetMetrics()
+	metric.RegisterMetrics()
+	defer gock.OffAll()
+	svc, ctrl, _, reset := s.newTestTenantController()
+	defer reset()
+	gock.New(test.ClusterURL).
+		Post(".*/rolebindingrestrictions").
+		Reply(500)
+	testdoubles.MockPostRequestsToOS(ptr.Int(0), test.ClusterURL, environment.DefaultEnvTypes, "johny")
+
+	// when
+	apptest.SetupTenantInternalServerError(s.T(), testdoubles.CreateAndMockUserAndToken(s.T(), uuid.NewV4().String(), false), svc, ctrl)
+
+	// then
+	s.verifyCount(metric.ProvisionedTenantsCounter, 1, "false")
+	s.verifyCount(metric.ProvisionedTenantsCounter, 0, "true")
+}
+
+func (s *MetricTestSuite) TestSuccessfulProvisionedTenantMetric() {
+	// given
+	defer unRegisterAndResetMetrics()
+	metric.RegisterMetrics()
+	defer gock.OffAll()
+	svc, ctrl, _, reset := s.newTestTenantController()
+	defer reset()
+	testdoubles.MockPostRequestsToOS(ptr.Int(0), test.ClusterURL, environment.DefaultEnvTypes, "johny")
+
+	// when
+	apptest.SetupTenantAccepted(s.T(), testdoubles.CreateAndMockUserAndToken(s.T(), uuid.NewV4().String(), false), svc, ctrl)
+
+	// then
+	s.verifyCount(metric.ProvisionedTenantsCounter, 0, "false")
+	s.verifyCount(metric.ProvisionedTenantsCounter, 1, "true")
+}
+
+func (s *MetricTestSuite) TestFailedUpdatedTenantMetric() {
+	// given
+	fxt := tf.FillDB(s.T(), s.DB, tf.AddSpecificTenants(tf.SingleWithName("johny")), tf.AddDefaultNamespaces())
+	id := fxt.Tenants[0].ID.String()
+	defer unRegisterAndResetMetrics()
+	metric.RegisterMetrics()
+	defer gock.OffAll()
+	svc, ctrl, _, reset := s.newTestTenantController()
+	defer reset()
+	gock.New(test.ClusterURL).
+		Get(".*/persistentvolumeclaims/.*").
+		Persist().
+		Reply(404)
+	gock.New(test.ClusterURL).
+		Post(".*/persistentvolumeclaims/.*").
+		Persist().
+		Reply(500)
+	testdoubles.MockPatchRequestsToOS(ptr.Int(0), test.ClusterURL)
+
+	// when
+	apptest.UpdateTenantInternalServerError(s.T(), testdoubles.CreateAndMockUserAndToken(s.T(), id, false), svc, ctrl)
+
+	// then
+	s.verifyCount(metric.UpdatedTenantsCounter, 1, "false", "johny")
+	s.verifyCount(metric.UpdatedTenantsCounter, 0, "true", "johny")
+}
+
+func (s *MetricTestSuite) TestSuccessfulUpdatedTenantMetric() {
+	// given
+	fxt := tf.FillDB(s.T(), s.DB, tf.AddSpecificTenants(tf.SingleWithName("johny")), tf.AddDefaultNamespaces())
+	id := fxt.Tenants[0].ID.String()
+	defer unRegisterAndResetMetrics()
+	metric.RegisterMetrics()
+	defer gock.OffAll()
+	svc, ctrl, _, reset := s.newTestTenantController()
+	defer reset()
+	testdoubles.MockPatchRequestsToOS(ptr.Int(0), test.ClusterURL)
+
+	// when
+	apptest.UpdateTenantAccepted(s.T(), testdoubles.CreateAndMockUserAndToken(s.T(), id, false), svc, ctrl)
+
+	// then
+	s.verifyCount(metric.UpdatedTenantsCounter, 0, "false", "johny")
+	s.verifyCount(metric.UpdatedTenantsCounter, 1, "true", "johny")
+}
+
+func (s *MetricTestSuite) TestFailedCleanedTenantMetric() {
+	// given
+	fxt := tf.FillDB(s.T(), s.DB, tf.AddSpecificTenants(tf.SingleWithName("johny")), tf.AddDefaultNamespaces())
+	id := fxt.Tenants[0].ID.String()
+	defer unRegisterAndResetMetrics()
+	metric.RegisterMetrics()
+	defer gock.OffAll()
+	svc, ctrl, _, reset := s.newTestTenantController()
+	defer reset()
+	gock.New(test.ClusterURL).
+		Get(".*-che.*/pods").
+		Persist().
+		Reply(202).
+		BodyString(`{"items": [
+        {"metadata": {"name": "workspace"}}]}`)
+	gock.New(test.ClusterURL).
+		Delete(".*/workspace").
+		Persist().
+		Reply(500)
+	testdoubles.MockPatchRequestsToOS(ptr.Int(0), test.ClusterURL)
+
+	// when
+	apptest.CleanTenantInternalServerError(s.T(), testdoubles.CreateAndMockUserAndToken(s.T(), id, false), svc, ctrl, false)
+
+	// then
+	s.verifyCount(metric.CleanedTenantsCounter, 1, "false", "johny")
+	s.verifyCount(metric.CleanedTenantsCounter, 0, "true", "johny")
+}
+
+func (s *MetricTestSuite) TestSuccessfulCleanedTenantMetric() {
+	// given
+	fxt := tf.FillDB(s.T(), s.DB, tf.AddSpecificTenants(tf.SingleWithName("johny")), tf.AddDefaultNamespaces())
+	id := fxt.Tenants[0].ID.String()
+	defer unRegisterAndResetMetrics()
+	metric.RegisterMetrics()
+	defer gock.OffAll()
+	svc, ctrl, _, reset := s.newTestTenantController()
+	defer reset()
+	testdoubles.MockPatchRequestsToOS(ptr.Int(0), test.ClusterURL)
+
+	// when
+	apptest.UpdateTenantAccepted(s.T(), testdoubles.CreateAndMockUserAndToken(s.T(), id, false), svc, ctrl)
+
+	// then
+	s.verifyCount(metric.UpdatedTenantsCounter, 0, "false", "johny")
+	s.verifyCount(metric.UpdatedTenantsCounter, 1, "true", "johny")
+}
+
+func (s *MetricTestSuite) verifyCount(counterVec *prometheus.CounterVec, expected int, labels ...string) {
+	counter, err := counterVec.GetMetricWithLabelValues(labels...)
+	require.NoError(s.T(), err)
+	metric := &dto.Metric{}
+	err = counter.Write(metric)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), expected, int(metric.Counter.GetValue()))
+}
+
+func (s *MetricTestSuite) newTestTenantController() (*goa.Service, *controller.TenantController, *configuration.Data, func()) {
+	testdoubles.MockCommunicationWithAuth(test.ClusterURL)
+	clusterService, authService, config, reset := testdoubles.PrepareConfigClusterAndAuthService(s.T())
+	svc := goa.New("Tenants-service")
+	ctrl := controller.NewTenantController(svc, tenant.NewDBService(s.DB), clusterService, authService, config)
+	return svc, ctrl, config, reset
+}
+
+func unRegisterAndResetMetrics() {
+	prometheus.Unregister(metric.ProvisionedTenantsCounter)
+	metric.ProvisionedTenantsCounter.Reset()
+	prometheus.Unregister(metric.CleanedTenantsCounter)
+	metric.CleanedTenantsCounter.Reset()
+	prometheus.Unregister(metric.UpdatedTenantsCounter)
+	metric.UpdatedTenantsCounter.Reset()
+}


### PR DESCRIPTION
adds monitoring metrics that record number of provisioned/updated/cleaned tenants.
Every record contains information whether the action was successful or failed. In addition, updated/cleaned records also contain namespace base name of the affected tenant.

Implements: [ODC-238](https://jira.coreos.com/browse/ODC-238)

Builds on top of https://github.com/fabric8-services/fabric8-tenant/pull/762, the actual commit that implements the metrics is this c4573fd 