### PR TITLE
disable check of unprovisioned namespaces for already provisioned tenant

### DIFF
--- a/controller/tenant.go
+++ b/controller/tenant.go
@@ -141,22 +141,24 @@ func (c *TenantController) Setup(ctx *app.SetupTenantContext) error {
 	// check if tenant already exists
 	if tenantRepository.Exists() {
 		// if exists, then check existing namespace (if all of them are created or if any is missing)
-		namespaces, err = tenantRepository.GetNamespaces()
-		if err != nil {
-			log.Error(ctx, map[string]interface{}{
-				"err":      err,
-				"tenantID": user.ID,
-			}, "retrieval of existing namespaces from DB failed")
-			return jsonapi.JSONErrorResponse(ctx, err)
-		}
-		dbTenant, err = c.getExistingTenant(ctx, user.ID, user.OpenShiftUsername)
-		if err != nil {
-			log.Error(ctx, map[string]interface{}{
-				"err":      err,
-				"tenantID": user.ID,
-			}, "retrieval of tenant entity from DB failed")
-			return jsonapi.JSONErrorResponse(ctx, errors.NewNotFoundError("tenant", user.ID.String()))
-		}
+		//namespaces, err = tenantRepository.GetNamespaces()
+		//if err != nil {
+		//	log.Error(ctx, map[string]interface{}{
+		//		"err":      err,
+		//		"tenantID": user.ID,
+		//	}, "retrieval of existing namespaces from DB failed")
+		//	return jsonapi.JSONErrorResponse(ctx, err)
+		//}
+		//dbTenant, err = c.getExistingTenant(ctx, user.ID, user.OpenShiftUsername)
+		//if err != nil {
+		//	log.Error(ctx, map[string]interface{}{
+		//		"err":      err,
+		//		"tenantID": user.ID,
+		//	}, "retrieval of tenant entity from DB failed")
+		//	return jsonapi.JSONErrorResponse(ctx, errors.NewNotFoundError("tenant", user.ID.String()))
+		//}
+
+		return ctx.Conflict()
 	} else {
 		nsBaseName, err := tenant.ConstructNsBaseName(c.tenantService, environment.RetrieveUserName(user.OpenShiftUsername))
 		if err != nil {

--- a/controller/tenant_test.go
+++ b/controller/tenant_test.go
@@ -235,6 +235,7 @@ func (s *TenantControllerTestSuite) TestSetupTenantOKWhenAlreadyExists() {
 	//cheObjects := testdoubles.SingleTemplatesObjectsWithDefaults(s.T(), config, environment.TypeChe)
 	//numberOfGetChecksForChe := testdoubles.NumberOfGetChecks(cheObjects)
 	//assert.Equal(s.T(), totalNumber-(len(cheObjects)+numberOfGetChecksForChe+1), calls)
+	assert.Equal(s.T(), 0, calls)
 }
 
 func (s *TenantControllerTestSuite) TestSetupUnauthorizedFailures() {

--- a/controller/tenant_test.go
+++ b/controller/tenant_test.go
@@ -194,7 +194,7 @@ func (s *TenantControllerTestSuite) TestSetupTenantOKWhenTenantExistsInParallelF
 				run.Wait()
 
 				// when
-				ctrl.Setup(setupCtx)
+				err = ctrl.Setup(setupCtx)
 
 				// then
 				if err != nil {


### PR DESCRIPTION
temporary workaround for https://github.com/redhat-developer/rh-che/issues/1296#issuecomment-475149410

It disables the check of unprovisioned namespaces for already provisioned tenants. This allows us to have an account with only two namespaces (che and user) provisioned