### PR TITLE
chore(ODC-125): delete run, stage, jenkins namespaces from tenant DB

### DIFF
--- a/migration/migration.go
+++ b/migration/migration.go
@@ -110,6 +110,7 @@ func getMigrations() migrations {
 	m = append(m, steps{executeSQLFile("007-create-tenants-update-table.sql")})
 	m = append(m, steps{executeSQLFile("008-add-can-continue-column-to-tenants-update.sql")})
 	m = append(m, steps{executeSQLFile("009-index-namespace-name.sql")})
+	m = append(m, steps{executeSQLFile("010-delete-run-stage-jenkins.sql")})
 
 	// Version N
 	//

--- a/migration/sql-files/010-delete-run-stage-jenkins.sql
+++ b/migration/sql-files/010-delete-run-stage-jenkins.sql
@@ -1,0 +1,1 @@
+DELETE FROM namespaces WHERE type = 'run' OR type = 'stage' OR type = 'jenkins';


### PR DESCRIPTION
as a migration step, it deletes `run`, `stage` and `jenkins` namespaces from the tenant DB