### PR TITLE
feat(ODC-238): add metric monitoring tenants deletion

### DIFF
--- a/controller/tenants.go
+++ b/controller/tenants.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"github.com/fabric8-services/fabric8-tenant/metric"
 	"reflect"
 
 	"fmt"
@@ -166,6 +167,7 @@ func (c *TenantsController) Delete(ctx *app.DeleteTenantsContext) error {
 	// perform delete method on the list of existing namespaces
 	err = service.Delete(environment.DefaultEnvTypes, namespaces, openshift.DeleteOpts().EnableSelfHealing().RemoveFromCluster())
 	if err != nil {
+		metric.RecordDeletedTenant(false)
 		namespaces, getErr := tenantRepository.GetNamespaces()
 		if getErr != nil {
 			log.Error(ctx, map[string]interface{}{
@@ -182,6 +184,7 @@ func (c *TenantsController) Delete(ctx *app.DeleteTenantsContext) error {
 
 	// the tenant should have been deleted - check it
 	if tenantRepository.Exists() {
+		metric.RecordDeletedTenant(false)
 		log.Error(ctx, map[string]interface{}{
 			"err":      err,
 			"tenantID": tenantID,
@@ -189,6 +192,7 @@ func (c *TenantsController) Delete(ctx *app.DeleteTenantsContext) error {
 		return jsonapi.JSONErrorResponse(ctx, fmt.Errorf("unable to delete tenant %s", tenantID))
 	}
 
+	metric.RecordDeletedTenant(true)
 	log.Info(ctx, map[string]interface{}{"tenant_id": tenantID}, "tenant deleted")
 	return ctx.NoContent()
 }

--- a/metric/metric.go
+++ b/metric/metric.go
@@ -6,25 +6,37 @@ import (
 	"strconv"
 )
 
+const (
+	provisionedTenantsTotalName = "provisioned_tenants_total"
+	cleanedTenantsTotalName     = "cleaned_tenants_total"
+	updatedTenantsTotalName     = "updated_tenants_total"
+	deletedTenantsTotalName     = "deleted_tenants_total"
+)
+
 var (
 	ProvisionedTenantsCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "provisioned_tenants_total",
+		Name: provisionedTenantsTotalName,
 		Help: "Total number of the provisioned tenants",
 	}, []string{"successful"})
+	DeletedTenantsCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: deletedTenantsTotalName,
+		Help: "Total number of the removed tenants",
+	}, []string{"successful"})
 	CleanedTenantsCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "cleaned_tenants_total",
+		Name: cleanedTenantsTotalName,
 		Help: "Total number of cleaned tenants",
 	}, []string{"successful", "nsBaseName"})
 	UpdatedTenantsCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "updated_tenants_total",
+		Name: updatedTenantsTotalName,
 		Help: "Total number of updated tenants",
 	}, []string{"successful", "nsBaseName"})
 )
 
 func RegisterMetrics() {
-	ProvisionedTenantsCounter = register(ProvisionedTenantsCounter, "provisioned_tenants_total").(*prometheus.CounterVec)
-	CleanedTenantsCounter = register(CleanedTenantsCounter, "cleaned_tenants_total").(*prometheus.CounterVec)
-	UpdatedTenantsCounter = register(UpdatedTenantsCounter, "updated_tenants_total").(*prometheus.CounterVec)
+	ProvisionedTenantsCounter = register(ProvisionedTenantsCounter, provisionedTenantsTotalName).(*prometheus.CounterVec)
+	DeletedTenantsCounter = register(DeletedTenantsCounter, deletedTenantsTotalName).(*prometheus.CounterVec)
+	CleanedTenantsCounter = register(CleanedTenantsCounter, cleanedTenantsTotalName).(*prometheus.CounterVec)
+	UpdatedTenantsCounter = register(UpdatedTenantsCounter, updatedTenantsTotalName).(*prometheus.CounterVec)
 	log.Info(nil, nil, "metrics registered successfully")
 }
 
@@ -48,7 +60,7 @@ func register(collector prometheus.Collector, name string) prometheus.Collector 
 func RecordProvisionedTenant(successful bool) {
 	if counter, err := ProvisionedTenantsCounter.GetMetricWithLabelValues(strconv.FormatBool(successful)); err != nil {
 		log.Error(nil, map[string]interface{}{
-			"metric_name": "provisioned_tenants_total",
+			"metric_name": provisionedTenantsTotalName,
 			"successful":  successful,
 			"err":         err,
 		}, "Failed to get metric")
@@ -60,7 +72,7 @@ func RecordProvisionedTenant(successful bool) {
 func RecordCleanedTenant(successful bool, nsBaseName string) {
 	if counter, err := CleanedTenantsCounter.GetMetricWithLabelValues(strconv.FormatBool(successful), nsBaseName); err != nil {
 		log.Error(nil, map[string]interface{}{
-			"metric_name": "cleaned_tenants_total",
+			"metric_name": cleanedTenantsTotalName,
 			"successful":  successful,
 			"nsBaseName":  nsBaseName,
 			"err":         err,
@@ -73,9 +85,21 @@ func RecordCleanedTenant(successful bool, nsBaseName string) {
 func RecordUpdatedTenant(successful bool, nsBaseName string) {
 	if counter, err := UpdatedTenantsCounter.GetMetricWithLabelValues(strconv.FormatBool(successful), nsBaseName); err != nil {
 		log.Error(nil, map[string]interface{}{
-			"metric_name": "updated_tenants_total",
+			"metric_name": updatedTenantsTotalName,
 			"successful":  successful,
 			"nsBaseName":  nsBaseName,
+			"err":         err,
+		}, "Failed to get metric")
+	} else {
+		counter.Inc()
+	}
+}
+
+func RecordDeletedTenant(successful bool) {
+	if counter, err := DeletedTenantsCounter.GetMetricWithLabelValues(strconv.FormatBool(successful)); err != nil {
+		log.Error(nil, map[string]interface{}{
+			"metric_name": deletedTenantsTotalName,
+			"successful":  successful,
 			"err":         err,
 		}, "Failed to get metric")
 	} else {

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -1,6 +1,8 @@
 package metric_test
 
 import (
+	"context"
+	"github.com/dgrijalva/jwt-go"
 	"github.com/fabric8-services/fabric8-common/convert/ptr"
 	"github.com/fabric8-services/fabric8-tenant/configuration"
 	"github.com/fabric8-services/fabric8-tenant/controller"
@@ -12,17 +14,49 @@ import (
 	"github.com/fabric8-services/fabric8-tenant/test/gormsupport"
 	tf "github.com/fabric8-services/fabric8-tenant/test/testfixture"
 	"github.com/goadesign/goa"
+	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"gopkg.in/h2non/gock.v1"
+	"io/ioutil"
+	"net/http/httptest"
 	"testing"
 
 	apptest "github.com/fabric8-services/fabric8-tenant/app/test"
 	dto "github.com/prometheus/client_model/go"
 )
+
+func TestMetricsEndpointExposesTenantSpecificMetrics(t *testing.T) {
+	// given
+	defer unRegisterAndResetMetrics()
+	metric.RegisterMetrics()
+	metric.RecordProvisionedTenant(true)
+	metric.RecordDeletedTenant(true)
+	metric.RecordDeletedTenant(false)
+	metric.RecordCleanedTenant(true, "")
+	metric.RecordUpdatedTenant(true, "")
+
+	handler := promhttp.Handler()
+
+	request := httptest.NewRequest("GET", "/metrics", nil)
+	response := httptest.NewRecorder()
+
+	// when
+	handler.ServeHTTP(response, request)
+
+	// then
+	body, err := ioutil.ReadAll(response.Body)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(body), "provisioned_tenants_total")
+	assert.Contains(t, string(body), "deleted_tenants_total")
+	assert.Contains(t, string(body), "cleaned_tenants_total")
+	assert.Contains(t, string(body), "updated_tenants_total")
+}
 
 type MetricTestSuite struct {
 	gormsupport.DBTestSuite
@@ -163,6 +197,57 @@ func (s *MetricTestSuite) TestSuccessfulCleanedTenantMetric() {
 	s.verifyCount(metric.UpdatedTenantsCounter, 1, "true", "johny")
 }
 
+func (s *MetricTestSuite) TestFailedDeletedTenantMetric() {
+	// given
+	fxt := tf.FillDB(s.T(), s.DB, tf.AddSpecificTenants(tf.SingleWithName("johny")), tf.AddDefaultNamespaces())
+	id := fxt.Tenants[0].ID
+	defer unRegisterAndResetMetrics()
+	metric.RegisterMetrics()
+	defer gock.OffAll()
+	testdoubles.MockCommunicationWithAuth(test.ClusterURL)
+	svc, ctrl, reset := s.newTestTenantsController()
+	defer reset()
+	gock.New(test.ClusterURL).
+		Delete(".*/projects/.*").
+		Persist().
+		Reply(500)
+	testdoubles.MockRemoveRequestsToOS(ptr.Int(0), test.ClusterURL)
+
+	// when
+	apptest.DeleteTenantsInternalServerError(s.T(), authContext(), svc, ctrl, id)
+
+	// then
+	s.verifyCount(metric.DeletedTenantsCounter, 1, "false")
+	s.verifyCount(metric.DeletedTenantsCounter, 0, "true")
+}
+
+func (s *MetricTestSuite) TestDeletedProvisionedTenantMetric() {
+	// given
+	fxt := tf.FillDB(s.T(), s.DB, tf.AddSpecificTenants(tf.SingleWithName("johny")), tf.AddDefaultNamespaces())
+	id := fxt.Tenants[0].ID
+	defer unRegisterAndResetMetrics()
+	metric.RegisterMetrics()
+	defer gock.OffAll()
+	testdoubles.MockCommunicationWithAuth(test.ClusterURL)
+	svc, ctrl, reset := s.newTestTenantsController()
+	defer reset()
+	testdoubles.MockRemoveRequestsToOS(ptr.Int(0), test.ClusterURL)
+
+	// when
+	apptest.DeleteTenantsNoContent(s.T(), authContext(), svc, ctrl, id)
+
+	// then
+	s.verifyCount(metric.DeletedTenantsCounter, 0, "false")
+	s.verifyCount(metric.DeletedTenantsCounter, 1, "true")
+}
+
+func authContext() context.Context {
+	claims := jwt.MapClaims{}
+	claims["service_accountname"] = "fabric8-auth"
+	token := jwt.NewWithClaims(jwt.SigningMethodRS512, claims)
+	return goajwt.WithJWT(context.Background(), token)
+}
+
 func (s *MetricTestSuite) verifyCount(counterVec *prometheus.CounterVec, expected int, labels ...string) {
 	counter, err := counterVec.GetMetricWithLabelValues(labels...)
 	require.NoError(s.T(), err)
@@ -180,6 +265,13 @@ func (s *MetricTestSuite) newTestTenantController() (*goa.Service, *controller.T
 	return svc, ctrl, config, reset
 }
 
+func (s *MetricTestSuite) newTestTenantsController() (*goa.Service, *controller.TenantsController, func()) {
+	clusterService, authService, config, reset := testdoubles.PrepareConfigClusterAndAuthService(s.T())
+	svc := goa.New("Tenants-service")
+	ctrl := controller.NewTenantsController(svc, tenant.NewDBService(s.DB), clusterService, authService, config)
+	return svc, ctrl, reset
+}
+
 func unRegisterAndResetMetrics() {
 	prometheus.Unregister(metric.ProvisionedTenantsCounter)
 	metric.ProvisionedTenantsCounter.Reset()
@@ -187,4 +279,6 @@ func unRegisterAndResetMetrics() {
 	metric.CleanedTenantsCounter.Reset()
 	prometheus.Unregister(metric.UpdatedTenantsCounter)
 	metric.UpdatedTenantsCounter.Reset()
+	prometheus.Unregister(metric.DeletedTenantsCounter)
+	metric.DeletedTenantsCounter.Reset()
 }


### PR DESCRIPTION
* adds metric monitoring (counting) tenants deletion
* use constants for the names of metrics
* add test checking that `/metrics` endpoints exposes the new metrics