### PR TITLE
fix(CRT-355): username shouldn't be a number nor start nor end with dash

### DIFF
--- a/environment/service_test.go
+++ b/environment/service_test.go
@@ -235,23 +235,3 @@ func TestConstructCompleteVersion(t *testing.T) {
 		assert.Equal(t, "345cde", completeVersion)
 	})
 }
-
-func TestCreateUsername(t *testing.T) {
-	assertName(t, "some", "some@email.com")
-	assertName(t, "so-me", "so-me@email.com")
-	assertName(t, "some", "some")
-	assertName(t, "so-me", "so-me")
-	assertName(t, "so-me", "so_me")
-	assertName(t, "so-me", "so me")
-	assertName(t, "so-me", "so me@email.com")
-	assertName(t, "so-me", "so.me")
-	assertName(t, "so-me", "so?me")
-	assertName(t, "so-me", "so:me")
-	assertName(t, "some1", "some1")
-	assertName(t, "so1me1", "so1me1")
-}
-
-func assertName(t *testing.T, expected, username string) {
-	assert.Regexp(t, dnsRegExp, environment.RetrieveUserName(username))
-	assert.Equal(t, expected, environment.RetrieveUserName(username))
-}

--- a/environment/template.go
+++ b/environment/template.go
@@ -195,7 +195,18 @@ func CollectVars(osUsername, nsBaseName, masterUser string, config *configuratio
 
 // RetrieveUserName returns a safe namespace basename based on a username
 func RetrieveUserName(openshiftUsername string) string {
-	return specialCharRegexp.ReplaceAllString(strings.Split(openshiftUsername, "@")[0], "-")
+	userName := specialCharRegexp.ReplaceAllString(strings.Split(openshiftUsername, "@")[0], "-")
+	if strings.HasPrefix(userName, "-") {
+		userName = "os" + userName
+	}
+	if strings.HasSuffix(userName, "-") {
+		userName = userName + "io"
+	}
+	matched, err := regexp.MatchString("^[0-9]*$", userName)
+	if matched || err != nil {
+		userName = "os-" + userName + "-io"
+	}
+	return userName
 }
 
 func getVariables(config *configuration.Data) map[string]string {

--- a/environment/template_test.go
+++ b/environment/template_test.go
@@ -260,3 +260,30 @@ func TestUseTemplateParams(t *testing.T) {
 	assert.Equal(t, "Test-Project-Name", environment.GetLabel(objects[0], "project_displayname"))
 
 }
+
+func TestRetrieveUserName(t *testing.T) {
+	assertName(t, "some", "some@email.com")
+	assertName(t, "so-me", "so-me@email.com")
+	assertName(t, "some", "some")
+	assertName(t, "so-me", "so-me")
+	assertName(t, "so-me", "so_me")
+	assertName(t, "so-me", "so me")
+	assertName(t, "so-me", "so me@email.com")
+	assertName(t, "so-me", "so.me")
+	assertName(t, "so-me", "so?me")
+	assertName(t, "so-me", "so:me")
+	assertName(t, "some1", "some1")
+	assertName(t, "so1me1", "so1me1")
+	assertName(t, "os-me", "-me")
+	assertName(t, "os-me", "_me")
+	assertName(t, "me-io", "me-")
+	assertName(t, "me-io", "me_")
+	assertName(t, "os-me-io", "_me_")
+	assertName(t, "os-me-io", "-me-")
+	assertName(t, "os-12345-io", "12345")
+}
+
+func assertName(t *testing.T, expected, username string) {
+	assert.Regexp(t, dnsRegExp, environment.RetrieveUserName(username))
+	assert.Equal(t, expected, environment.RetrieveUserName(username))
+}

--- a/environment/templates/fabric8-tenant-user.yml
+++ b/environment/templates/fabric8-tenant-user.yml
@@ -12,8 +12,8 @@ objects:
   kind: ProjectRequest
   metadata:
     annotations:
-      openshift.io/description: ${USER_NAME}
-      openshift.io/display-name: ${USER_NAME}
+      openshift.io/description: ${USER_NAME} User Environment
+      openshift.io/display-name: ${USER_NAME} User
       openshift.io/requester: ${PROJECT_REQUESTING_USER}
     labels:
       provider: fabric8


### PR DESCRIPTION
the userName that is used for namespace provisioning shouldn't start nor end with dash and shouldn't be a number. If it doesn't comply with these conditions, then it gets either `os` prefix or `io` suffix or both.
Also changed the failing User template so the problematic annotation is in a format of string (similarly as is done in Che template)