### PR TITLE
fix(CRT-355): use all vars as strings in all templates

### DIFF
--- a/environment/templates/fabric8-tenant-che-mt.yml
+++ b/environment/templates/fabric8-tenant-che-mt.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: fabric8-tenant-che-mt
     provider: fabric8
-    version: ${COMMIT}
+    version: "${COMMIT}"
   name: fabric8-tenant-che-mt
 objects:
 - apiVersion: v1
@@ -18,53 +18,53 @@ objects:
     labels:
       app: fabric8-tenant-che
       provider: fabric8
-      version: ${COMMIT}
-      version-quotas: ${COMMIT_QUOTAS}
-    name: ${USER_NAME}-che
+      version: "${COMMIT}"
+      version-quotas: "${COMMIT_QUOTAS}"
+    name: "${USER_NAME}-che"
 - apiVersion: v1
   kind: RoleBindingRestriction
   metadata:
     labels:
       app: fabric8-tenant-che-mt
       provider: fabric8
-      version: ${COMMIT}
-      version-quotas: ${COMMIT_QUOTAS}
+      version: "${COMMIT}"
+      version-quotas: "${COMMIT_QUOTAS}"
     name: dsaas-user-access
-    namespace: ${USER_NAME}-che
+    namespace: "${USER_NAME}-che"
   spec:
     userrestriction:
       users:
-      - ${PROJECT_USER}
+      - "${PROJECT_USER}"
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
     labels:
       app: fabric8-tenant-che-mt
       provider: fabric8
-      version: ${COMMIT}
-      version-quotas: ${COMMIT_QUOTAS}
+      version: "${COMMIT}"
+      version-quotas: "${COMMIT_QUOTAS}"
     name: che
-    namespace: ${USER_NAME}-che
+    namespace: "${USER_NAME}-che"
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
     labels:
       app: fabric8-tenant-che-mt
       provider: fabric8
-      version: ${COMMIT}
-      version-quotas: ${COMMIT_QUOTAS}
+      version: "${COMMIT}"
+      version-quotas: "${COMMIT_QUOTAS}"
     name: che-workspace
-    namespace: ${USER_NAME}-che
+    namespace: "${USER_NAME}-che"
 - apiVersion: v1
   kind: Role
   metadata:
     labels:
       app: fabric8-tenant-che-mt
       provider: fabric8
-      version: ${COMMIT}
-      version-quotas: ${COMMIT_QUOTAS}
+      version: "${COMMIT}"
+      version-quotas: "${COMMIT_QUOTAS}"
     name: exec
-    namespace: ${USER_NAME}-che
+    namespace: "${USER_NAME}-che"
   rules:
   - apiGroups:
     - ""
@@ -78,10 +78,10 @@ objects:
     labels:
       app: fabric8-tenant-che-mt
       provider: fabric8
-      version: ${COMMIT}
-      version-quotas: ${COMMIT_QUOTAS}
+      version: "${COMMIT}"
+      version-quotas: "${COMMIT_QUOTAS}"
     name: che-edit
-    namespace: ${USER_NAME}-che
+    namespace: "${USER_NAME}-che"
   roleRef:
     name: edit
   subjects:
@@ -93,48 +93,48 @@ objects:
     labels:
       app: fabric8-tenant-che-mt
       provider: fabric8
-      version: ${COMMIT}
-      version-quotas: ${COMMIT_QUOTAS}
+      version: "${COMMIT}"
+      version-quotas: "${COMMIT_QUOTAS}"
     name: user-exec
-    namespace: ${USER_NAME}-che
+    namespace: "${USER_NAME}-che"
   roleRef:
     name: exec
-    namespace: ${USER_NAME}-che
+    namespace: "${USER_NAME}-che"
   subjects:
   - kind: User
-    name: ${PROJECT_USER}
+    name: "${PROJECT_USER}"
   userNames:
-  - ${PROJECT_USER}
+  - "${PROJECT_USER}"
 - apiVersion: v1
   kind: RoleBinding
   metadata:
     labels:
       app: fabric8-tenant-che-mt
       provider: fabric8
-      version: ${COMMIT}
-      version-quotas: ${COMMIT_QUOTAS}
+      version: "${COMMIT}"
+      version-quotas: "${COMMIT_QUOTAS}"
     name: user-view
-    namespace: ${USER_NAME}-che
+    namespace: "${USER_NAME}-che"
   roleRef:
     name: view
   subjects:
   - kind: User
-    name: ${PROJECT_USER}
+    name: "${PROJECT_USER}"
   userNames:
-  - ${PROJECT_USER}
+  - "${PROJECT_USER}"
 - apiVersion: v1
   kind: RoleBinding
   metadata:
     labels:
       app: fabric8-tenant-che-mt
       provider: fabric8
-      version: ${COMMIT}
-      version-quotas: ${COMMIT_QUOTAS}
+      version: "${COMMIT}"
+      version-quotas: "${COMMIT_QUOTAS}"
     name: workspace-exec
-    namespace: ${USER_NAME}-che
+    namespace: "${USER_NAME}-che"
   roleRef:
     name: exec
-    namespace: ${USER_NAME}-che
+    namespace: "${USER_NAME}-che"
   subjects:
   - kind: ServiceAccount
     name: che-workspace
@@ -144,10 +144,10 @@ objects:
     labels:
       app: fabric8-tenant-che-mt
       provider: fabric8
-      version: ${COMMIT}
-      version-quotas: ${COMMIT_QUOTAS}
+      version: "${COMMIT}"
+      version-quotas: "${COMMIT_QUOTAS}"
     name: workspace-view
-    namespace: ${USER_NAME}-che
+    namespace: "${USER_NAME}-che"
   roleRef:
     name: view
   subjects:
@@ -159,10 +159,10 @@ objects:
     labels:
       app: fabric8-tenant-che-mt
       provider: fabric8
-      version: ${COMMIT}
-      version-quotas: ${COMMIT_QUOTAS}
+      version: "${COMMIT}"
+      version-quotas: "${COMMIT_QUOTAS}"
     name: claim-che-workspace
-    namespace: ${USER_NAME}-che
+    namespace: "${USER_NAME}-che"
   spec:
     accessModes:
     - ReadWriteOnce

--- a/environment/templates/fabric8-tenant-che-quotas.yml
+++ b/environment/templates/fabric8-tenant-che-quotas.yml
@@ -8,9 +8,9 @@ items:
     labels:
       app: fabric8-tenant-che-quotas
       provider: fabric8
-      version: ${COMMIT_QUOTAS}
+      version: "${COMMIT_QUOTAS}"
     name: resource-limits
-    namespace: ${USER_NAME}-che
+    namespace: "${USER_NAME}-che"
   spec:
     limits:
     - max:
@@ -44,9 +44,9 @@ items:
     labels:
       app: fabric8-tenant-che-quotas
       provider: fabric8
-      version: ${COMMIT_QUOTAS}
+      version: "${COMMIT_QUOTAS}"
     name: compute-resources
-    namespace: ${USER_NAME}-che
+    namespace: "${USER_NAME}-che"
   spec:
     hard:
       limits.cpu: "6"
@@ -59,9 +59,9 @@ items:
     labels:
       app: fabric8-tenant-che-quotas
       provider: fabric8
-      version: ${COMMIT_QUOTAS}
+      version: "${COMMIT_QUOTAS}"
     name: compute-resources-timebound
-    namespace: ${USER_NAME}-che
+    namespace: "${USER_NAME}-che"
   spec:
     hard:
       limits.cpu: "6"
@@ -74,9 +74,9 @@ items:
     labels:
       app: fabric8-tenant-che-quotas
       provider: fabric8
-      version: ${COMMIT_QUOTAS}
+      version: "${COMMIT_QUOTAS}"
     name: object-counts
-    namespace: ${USER_NAME}-che
+    namespace: "${USER_NAME}-che"
   spec:
     hard:
       persistentvolumeclaims: "2"

--- a/environment/templates/fabric8-tenant-user.yml
+++ b/environment/templates/fabric8-tenant-user.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     provider: fabric8
     project: fabric8-tenant-user
-    version: ${COMMIT}
+    version: "${COMMIT}"
   name: fabric8-tenant-user
 objects:
 - apiVersion: v1
@@ -18,69 +18,69 @@ objects:
     labels:
       provider: fabric8
       project: fabric8-tenant-user
-      version: ${COMMIT}
-    name: ${USER_NAME}
+      version: "${COMMIT}"
+    name: "${USER_NAME}"
 - apiVersion: v1
   kind: RoleBinding
   metadata:
     labels:
       app: fabric8-tenant-user
       provider: fabric8
-      version: ${COMMIT}
+      version: "${COMMIT}"
     name: user-edit
-    namespace: ${USER_NAME}
+    namespace: "${USER_NAME}"
   roleRef:
     name: edit
   subjects:
   - kind: User
-    name: ${PROJECT_USER}
+    name: "${PROJECT_USER}"
   userNames:
-  - ${PROJECT_USER}
+  - "${PROJECT_USER}"
 - apiVersion: v1
   kind: RoleBinding
   metadata:
     labels:
       app: fabric8-tenant-user
       provider: fabric8
-      version: ${COMMIT}
+      version: "${COMMIT}"
     name: user-view
-    namespace: ${USER_NAME}
+    namespace: "${USER_NAME}"
   roleRef:
     name: view
   subjects:
   - kind: User
-    name: ${PROJECT_USER}
+    name: "${PROJECT_USER}"
   userNames:
-  - ${PROJECT_USER}
+  - "${PROJECT_USER}"
 - apiVersion: v1
   kind: RoleBindingRestriction
   metadata:
     labels:
       app: fabric8-tenant-user
       provider: fabric8
-      version: ${COMMIT}
+      version: "${COMMIT}"
     name: dsaas-access-users
-    namespace: ${USER_NAME}
+    namespace: "${USER_NAME}"
   spec:
     userrestriction:
       users:
-      - ${PROJECT_ADMIN_USER}
+      - "${PROJECT_ADMIN_USER}"
 - apiVersion: v1
   kind: RoleBinding
   metadata:
     labels:
       app: fabric8-tenant-user
       provider: fabric8
-      version: ${COMMIT}
+      version: "${COMMIT}"
     name: dsaas-admin
-    namespace: ${USER_NAME}
+    namespace: "${USER_NAME}"
   roleRef:
     name: admin
   subjects:
   - kind: User
-    name: ${PROJECT_ADMIN_USER}
+    name: "${PROJECT_ADMIN_USER}"
   userNames:
-  - ${PROJECT_ADMIN_USER}
+  - "${PROJECT_ADMIN_USER}"
 parameters:
 - name: USER_NAME
   value: developer


### PR DESCRIPTION
use all vars as strings in all templates because not only annotations have a problem with a username containing only numbers, but also RoleBindings. Yes, I'm stupid that I didn't realize it before :-/ 