### PR TITLE
Set max CPU limit to 14 cores per Pod

### DIFF
--- a/environment/templates/fabric8-tenant-che-quotas.yml
+++ b/environment/templates/fabric8-tenant-che-quotas.yml
@@ -14,7 +14,7 @@ items:
   spec:
     limits:
     - max:
-        cpu: 6000m
+        cpu: 14000m
         memory: 7Gi
       min:
         cpu: 29m
@@ -27,7 +27,7 @@ items:
         cpu: 60m
         memory: 307Mi
       max:
-        cpu: 6000m
+        cpu: 14000m
         memory: 7Gi
       min:
         cpu: 29m
@@ -49,7 +49,7 @@ items:
     namespace: "${USER_NAME}-che"
   spec:
     hard:
-      limits.cpu: "6"
+      limits.cpu: "14"
       limits.memory: 7Gi
     scopes:
     - NotTerminating
@@ -64,7 +64,7 @@ items:
     namespace: "${USER_NAME}-che"
   spec:
     hard:
-      limits.cpu: "6"
+      limits.cpu: "14"
       limits.memory: 7Gi
     scopes:
     - Terminating


### PR DESCRIPTION
Since there is ClusterResourceOverride admissionConfig plugin in OSO clusters with limitCPUToMemoryPercent=200 (or so) we need to set the max CPU limit per Pod to x2 of what we have for memory.

It seems that CPU limits in all the containers in a Pod are set (overridden) to 200% of the memory limits.
For example if the summery of all the memory limits of all the containers of a Pod is 7Gi then the summery of the CPU limits of those containers will be 14 cores. So we have to set the LimitRange for a Pod to 14 cores too. Otherwise the summery of the containers limits will be bigger than the max CPU allowed by the LimitRange.

See https://docs.openshift.com/container-platform/3.11/admin_guide/overcommit.html#configuring-masters-for-overcommitment for details.