### PR TITLE
Increasing size of the 'claim-che-workspace' PVC to 2GB

### DIFF
--- a/environment/templates/fabric8-tenant-che-mt.yml
+++ b/environment/templates/fabric8-tenant-che-mt.yml
@@ -168,7 +168,7 @@ objects:
     - ReadWriteOnce
     resources:
       requests:
-        storage: 1Gi
+        storage: 2Gi
 parameters:
 - name: USER_NAME
   value: developer


### PR DESCRIPTION
## Motivation
After increasing RAM to 7GB Hosted Che user is able to start an advanced workspace with multiple plugins / extensions enabled, but it is still not be possible to simply build a relatively small project in this workspace due to the PVC size that should be also increased.

## Reasoning
Since Jenkins / build namespace was removed some time ago which included 1GB PVC we can consider adding this storage to the *-che namespace. Resource wise this should be safe since we do not increase the number of PVC and just relocating the storage that was available initially on openshift.io. 

## Process

Our current assumption is that after the cluster-wide tenant update during existing PVCs would be automatically resized but we need to verify it against prod-preview:
- merge this PR
- proceed with tenant update against prod-preview